### PR TITLE
Fix formatting for flake8 compliance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 119

--- a/vinyldns_python/boto_request_signer.py
+++ b/vinyldns_python/boto_request_signer.py
@@ -31,11 +31,11 @@ class BotoRequestSigner(object):
     def __init__(self, index_url, access_key, secret_access_key):
         url = urlparse.urlparse(index_url)
         self.boto_connection = DynamoDBConnection(
-            host = url.hostname,
-            port = url.port,
-            aws_access_key_id = access_key,
-            aws_secret_access_key = secret_access_key,
-            is_secure = False)
+            host=url.hostname,
+            port=url.port,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_access_key,
+            is_secure=False)
 
     @staticmethod
     def canonical_date(headers):

--- a/vinyldns_python/client.py
+++ b/vinyldns_python/client.py
@@ -40,6 +40,7 @@ __all__ = [u'VinylDNSClient', u'MAX_RETRIES', u'RETRY_WAIT']
 MAX_RETRIES = 30
 RETRY_WAIT = 0.05
 
+
 class VinylDNSClient(object):
 
     def __init__(self, url, access_key, secret_key):
@@ -93,7 +94,8 @@ class VinylDNSClient(object):
         session.mount(u'https://', adapter)
         return session
 
-    def make_request(self, url, method=u'GET', headers=None, body_string=None, sign_request=True, not_found_ok=False, **kwargs):
+    def make_request(self, url, method=u'GET', headers=None, body_string=None,
+                     sign_request=True, not_found_ok=False, **kwargs):
 
         # remove retries arg if provided
         kwargs.pop(u'retries', None)
@@ -107,24 +109,25 @@ class VinylDNSClient(object):
         if query:
             # the problem with parse_qs is that it will return a list for ALL params, even if they are a single value
             # we need to essentially flatten the params if a param has only one value
-            query = dict((k, v if len(v)>1 else v[0])
+            query = dict((k, v if len(v) > 1 else v[0])
                          for k, v in iteritems(query))
 
         if sign_request:
             signed_headers, signed_body = self.build_vinyldns_request(method, path, body_string, query,
-                                                                   with_headers=headers or {}, **kwargs)
+                                                                      with_headers=headers or {}, **kwargs)
         else:
             signed_headers = headers or {}
             signed_body = body_string
 
         if not_found_ok:
-            response = self.session_not_found_ok.request(method, url, data=signed_body, headers=signed_headers, **kwargs)
+            response = self.session_not_found_ok.request(method, url, data=signed_body,
+                                                         headers=signed_headers, **kwargs)
         else:
             response = self.session.request(method, url, data=signed_body, headers=signed_headers, **kwargs)
 
         try:
             return response.status_code, response.json()
-        except:
+        except Exception:
             return response.status_code, response.text
 
     def ping(self):
@@ -511,7 +514,8 @@ class VinylDNSClient(object):
         """
         url = urljoin(self.index_url, u'/zones/{0}/recordsets/{1}'.format(recordset[u'zoneId'], recordset[u'id']))
 
-        response, data = self.make_request(url, u'PUT', self.headers, json.dumps(recordset), not_found_ok=True, **kwargs)
+        response, data = self.make_request(url, u'PUT', self.headers,
+                                           json.dumps(recordset), not_found_ok=True, **kwargs)
         return data
 
     def get_recordset(self, zone_id, rs_id, **kwargs):
@@ -647,7 +651,8 @@ class VinylDNSClient(object):
         :return: the content of the response
         """
         url = urljoin(self.index_url, '/zones/{0}/acl/rules'.format(zone_id))
-        response, data = self.make_request(url, 'PUT', self.headers, json.dumps(acl_rule), sign_request=sign_request, **kwargs)
+        response, data = self.make_request(url, 'PUT', self.headers,
+                                           json.dumps(acl_rule), sign_request=sign_request, **kwargs)
 
         return data
 
@@ -660,6 +665,7 @@ class VinylDNSClient(object):
         :return: the content of the response
         """
         url = urljoin(self.index_url, '/zones/{0}/acl/rules'.format(zone_id))
-        response, data = self.make_request(url, 'DELETE', self.headers, json.dumps(acl_rule), sign_request=sign_request, **kwargs)
+        response, data = self.make_request(url, 'DELETE', self.headers,
+                                           json.dumps(acl_rule), sign_request=sign_request, **kwargs)
 
         return data


### PR DESCRIPTION
For addressing https://github.com/vinyldns/vinyldns-python/issues/14

The command for travis would just be:

```
flake8
```

If there are errors, the return code will be different than 0 and the build will fail :+1: 