### PR TITLE
Fixing release issues

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,3 +4,6 @@ virtualenv --clear --python="$(which python3)" ./.virtualenv
 
 echo "Installing dependencies..."
 python3 setup.py install
+
+echo "Installing twine..."
+pip install twine

--- a/release.sh
+++ b/release.sh
@@ -90,8 +90,8 @@ twine upload ${RELEASE_URL} ${DIR}/dist/*
 
 if [[ "$GIT_PUSH" == "true" ]]; then
     echo "Pushing git tags..."
-    #git push
-    #git push --tags
+    git push
+    git push --tags
 else
     echo "Skipping push to git!"
 fi


### PR DESCRIPTION
When I last ran the release, I found:

1. `twine` was not installed by default.  I didn't want to add it to the `setup` so I just inlined it in the `./bootstrap.sh`
1. Uncommented out code.  I ran the release, but git push and git push tags was off.  So I manually did a `git push` and `git push --tags` to finish the release.  Uncommented out that code.