### PR TITLE
Fixing issue with batch change serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,5 @@ venv.bak/
 # misc
 .idea/
 .DS_Store
+.vscode
 

--- a/func_tests/test_client.py
+++ b/func_tests/test_client.py
@@ -2,6 +2,7 @@ from func_tests.vinyldns_context import vinyldns_test_context
 from vinyldns.batch_change import AddRecordChange, DeleteRecordSetChange, BatchChange, BatchChangeRequest, \
     DeleteRecordSet, AddRecord, BatchChangeSummary, ListBatchChangeSummaries
 from vinyldns.record import RecordSet, RecordType, AData, AAAAData, PTRData
+from func_tests.utils import wait_until_record_set_exists
 
 
 def test_list_zones(vinyldns_test_context):
@@ -37,6 +38,15 @@ def test_record_sets(vinyldns_test_context):
     assert change.record_set.ttl == rs.ttl
     assert change.record_set.name == rs.name
     assert all([l.__dict__ == r.__dict__ for l, r in zip(change.record_set.records, rs.records)])
+
+    rs = change.record_set
+    wait_until_record_set_exists(vinyldns_test_context.client, rs.zone_id, rs.id)
+
+    r = vinyldns_test_context.client.get_record_set(rs.zone_id, rs.id)
+    assert r.id == rs.id
+    assert r.name == rs.name
+    assert r.ttl == rs.ttl
+    assert all([l.__dict__ == r.__dict__ for l, r in zip(rs.records, r.records)])
 
 
 def test_batch_change(vinyldns_test_context):

--- a/func_tests/test_client.py
+++ b/func_tests/test_client.py
@@ -1,5 +1,7 @@
 from func_tests.vinyldns_context import vinyldns_test_context
-from vinyldns.record import RecordSet, RecordType, AData
+from vinyldns.batch_change import AddRecordChange, DeleteRecordSetChange, BatchChange, BatchChangeRequest, \
+    DeleteRecordSet, AddRecord, BatchChangeSummary, ListBatchChangeSummaries
+from vinyldns.record import RecordSet, RecordType, AData, AAAAData, PTRData
 
 
 def test_list_zones(vinyldns_test_context):
@@ -35,4 +37,29 @@ def test_record_sets(vinyldns_test_context):
     assert change.record_set.ttl == rs.ttl
     assert change.record_set.name == rs.name
     assert all([l.__dict__ == r.__dict__ for l, r in zip(change.record_set.records, rs.records)])
+
+
+def test_batch_change(vinyldns_test_context):
+    changes = [
+        AddRecord('change-test.vinyldns.', RecordType.A, 200, AData('192.0.2.111')),
+        AddRecord('192.0.2.111', RecordType.PTR, 200, PTRData('change-test.vinyldns.'))
+    ]
+    r = vinyldns_test_context.client.create_batch_change(
+        BatchChangeRequest(changes, 'comments', vinyldns_test_context.group.id)
+    )
+    assert r.user_id == 'ok'
+    assert r.user_name == 'ok'
+    assert r.comments == 'comments'
+
+    change1 = r.changes[0]
+    assert change1.input_name == 'change-test.vinyldns.'
+    assert change1.ttl == 200
+    assert change1.record.address == '192.0.2.111'
+    assert change1.type == RecordType.A
+
+    change2 = r.changes[1]
+    assert change2.input_name == '192.0.2.111'
+    assert change2.ttl == 200
+    assert change2.record.ptrdname == 'change-test.vinyldns.'
+    assert change2.type == RecordType.PTR
 

--- a/func_tests/utils.py
+++ b/func_tests/utils.py
@@ -17,9 +17,6 @@ def wait_until_zone_exists(vinyldns_client, zone_id):
         time.sleep(RETRY_WAIT)
         retries -= 1
 
-    if zone is None:
-        print("Issue on zone create: {}".format(json.dumps(zone)))
-
     assert zone is not None
 
 
@@ -34,7 +31,18 @@ def wait_until_zone_deleted(vinyldns_client, zone_id):
         time.sleep(RETRY_WAIT)
         retries -= 1
 
-    if zone is not None:
-        print("Zone was not deleted: {}".format(json.dumps(zone)))
-
     assert zone is None
+
+
+def wait_until_record_set_exists(vinyldns_client, zone_id, rs_id):
+    """
+    Waits until the zone exists
+    """
+    rs = vinyldns_client.get_record_set(zone_id, rs_id)
+    retries = MAX_RETRIES
+    while (rs is None) and retries > 0:
+        rs = vinyldns_client.get_record_set(zone_id, rs_id)
+        time.sleep(RETRY_WAIT)
+        retries -= 1
+
+    assert rs is not None

--- a/func_tests/vinyldns_context.py
+++ b/func_tests/vinyldns_context.py
@@ -34,7 +34,6 @@ class VinylDNSContext(object):
         zone_change = self.client.connect_zone(zone)
         self.zone = zone_change.zone
 
-
         reverse_zone = Zone(
             name='2.0.192.in-addr.arpa.',
             email='test@test.com',
@@ -63,13 +62,9 @@ class VinylDNSContext(object):
 
         # we only want to delete zones that the ok user "owns"
         zones_to_delete = list(filter(lambda x: x.admin_group_id in group_ids, zones))
-        for zone in zones_to_delete:
-            print("Zone to delete %s" % zone.name)
-
         zoneids_to_delete = list(map(lambda x: x.id, zones_to_delete))
 
         for id in zoneids_to_delete:
-            print("Going to abandon zone id %s" %id)
             self.client.abandon_zone(id)
             wait_until_zone_deleted(self.client, id)
 

--- a/func_tests/vinyldns_context.py
+++ b/func_tests/vinyldns_context.py
@@ -13,8 +13,8 @@ class VinylDNSContext(object):
     """
     def __init__(self):
         self.client = VinylDNSClient("http://localhost:9000", "okAccessKey", "okSecretKey")
-        self.tear_down()
         self.group = None
+        self.tear_down()
 
         group = Group(
             name='vinyldns-python-test-group',
@@ -33,7 +33,16 @@ class VinylDNSContext(object):
         )
         zone_change = self.client.connect_zone(zone)
         self.zone = zone_change.zone
-        wait_until_zone_exists(self.client, self.zone.id)
+
+
+        reverse_zone = Zone(
+            name='2.0.192.in-addr.arpa.',
+            email='test@test.com',
+            admin_group_id=self.group.id
+        )
+        zone_change = self.client.connect_zone(reverse_zone)
+        self.reverse_zone = zone_change.zone
+        wait_until_zone_exists(self.client, self.reverse_zone.id)
 
     # finalizer called by py.test when the simulation is torn down
     def tear_down(self):
@@ -48,16 +57,19 @@ class VinylDNSContext(object):
     def clear_zones(self):
         # Get the groups for the ok user
         groups = self.client.list_all_my_groups().groups
-        group_ids = map(lambda x: x.id, groups)
+        group_ids = list(map(lambda x: x.id, groups))
 
         zones = self.client.list_zones().zones
 
         # we only want to delete zones that the ok user "owns"
-        zones_to_delete = filter(lambda x: (x.admin_group_id in group_ids), zones)
+        zones_to_delete = list(filter(lambda x: x.admin_group_id in group_ids, zones))
+        for zone in zones_to_delete:
+            print("Zone to delete %s" % zone.name)
 
-        zoneids_to_delete = map(lambda x: x.id, zones_to_delete)
+        zoneids_to_delete = list(map(lambda x: x.id, zones_to_delete))
 
         for id in zoneids_to_delete:
+            print("Going to abandon zone id %s" %id)
             self.client.abandon_zone(id)
             wait_until_zone_deleted(self.client, id)
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ with open('README.md') as f:
 setup(
     cmdclass={'test': PyTest},
     name='vinyldns-python',
-    version='0.9.0',
+    version='0.9.1',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ with open('README.md') as f:
 setup(
     cmdclass={'test': PyTest},
     name='vinyldns-python',
-    version='0.9.1',
+    version='0.9.0',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],

--- a/src/vinyldns/batch_change.py
+++ b/src/vinyldns/batch_change.py
@@ -89,7 +89,6 @@ class AddRecordChange(object):
 
     @staticmethod
     def from_dict(d):
-        print(d['record'])
         return AddRecordChange(
             zone_id=d['zoneId'],
             zone_name=d['zoneName'],

--- a/src/vinyldns/batch_change.py
+++ b/src/vinyldns/batch_change.py
@@ -16,6 +16,7 @@
 from vinyldns.serdes import parse_datetime, map_option
 from vinyldns.record import rdata_converters
 
+
 class AddRecord(object):
     def __init__(self, input_name, type, ttl, record):
         self.input_name = input_name
@@ -85,7 +86,6 @@ class AddRecordChange(object):
         self.record_change_id = record_change_id
         self.record_set_id = record_set_id
         self.change_type = 'Add'
-
 
     @staticmethod
     def from_dict(d):

--- a/src/vinyldns/batch_change.py
+++ b/src/vinyldns/batch_change.py
@@ -14,7 +14,7 @@
 """TODO: Add module docstring."""
 
 from vinyldns.serdes import parse_datetime, map_option
-
+from vinyldns.record import rdata_converters
 
 class AddRecord(object):
     def __init__(self, input_name, type, ttl, record):
@@ -70,7 +70,7 @@ class BatchChangeRequest(object):
 
 
 class AddRecordChange(object):
-    def __init__(self, zone_id, zone_name, record_name, input_name, type, ttl, record_data, status, id,
+    def __init__(self, zone_id, zone_name, record_name, input_name, type, ttl, record, status, id,
                  system_message=None, record_change_id=None, record_set_id=None):
         self.zone_id = zone_id
         self.zone_name = zone_name
@@ -78,7 +78,7 @@ class AddRecordChange(object):
         self.input_name = input_name
         self.type = type
         self.ttl = ttl
-        self.record_data = record_data,
+        self.record = record
         self.status = status
         self.id = id
         self.system_message = system_message
@@ -86,8 +86,10 @@ class AddRecordChange(object):
         self.record_set_id = record_set_id
         self.change_type = 'Add'
 
+
     @staticmethod
     def from_dict(d):
+        print(d['record'])
         return AddRecordChange(
             zone_id=d['zoneId'],
             zone_name=d['zoneName'],
@@ -95,7 +97,7 @@ class AddRecordChange(object):
             input_name=d['inputName'],
             type=d['type'],
             ttl=d['ttl'],
-            record_data=d['recordData'],
+            record=rdata_converters[d['type']](d['record']),
             status=d['status'],
             id=d['id'],
             system_message=d.get('systemMessage'),

--- a/src/vinyldns/client.py
+++ b/src/vinyldns/client.py
@@ -520,8 +520,8 @@ class VinylDNSClient(object):
         """
         url = urljoin(self.index_url, u'/zones/{0}/recordsets/{1}'.format(zone_id, rs_id))
 
-        response, data = self.__make_request(url, u'GET', self.headers, None, **kwargs)
-        return RecordSet.from_dict(data) if data is not None else None
+        response, data = self.__make_request(url, u'GET', self.headers, None, **kwargs)        
+        return RecordSet.from_dict(data['recordSet']) if data is not None else None
 
     def list_record_sets(self, zone_id, start_from=None, max_items=None, record_name_filter=None, **kwargs):
         """

--- a/src/vinyldns/client.py
+++ b/src/vinyldns/client.py
@@ -520,7 +520,7 @@ class VinylDNSClient(object):
         """
         url = urljoin(self.index_url, u'/zones/{0}/recordsets/{1}'.format(zone_id, rs_id))
 
-        response, data = self.__make_request(url, u'GET', self.headers, None, **kwargs)        
+        response, data = self.__make_request(url, u'GET', self.headers, None, **kwargs)
         return RecordSet.from_dict(data['recordSet']) if data is not None else None
 
     def list_record_sets(self, zone_id, start_from=None, max_items=None, record_name_filter=None, **kwargs):

--- a/tests/test_batch_change.py
+++ b/tests/test_batch_change.py
@@ -17,7 +17,7 @@ from datetime import datetime
 import responses
 from sampledata import forward_zone
 from vinyldns.record import RecordType, AData
-from vinyldns.serdes import to_json_string, to_dict
+from vinyldns.serdes import to_json_string
 from vinyldns.batch_change import AddRecordChange, DeleteRecordSetChange, BatchChange, BatchChangeRequest, \
     DeleteRecordSet, AddRecord, BatchChangeSummary, ListBatchChangeSummaries
 
@@ -42,9 +42,9 @@ def test_create_batch_change(mocked_responses, vinyldns_client):
     ar = AddRecord('foo.bar.com', RecordType.A, 100, AData('1.2.3.4'))
     drs = DeleteRecordSet('baz.bar.com', RecordType.A)
 
-    arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, 200, AData('1.2.3.4'),
-                          'Complete', 'id1', 'system-message', 'rchangeid1', 'rsid1')
-                          
+    arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, 200,
+                          AData('1.2.3.4'), 'Complete', 'id1', 'system-message', 'rchangeid1', 'rsid1')
+
     drc = DeleteRecordSetChange(forward_zone.id, forward_zone.name, 'baz', 'baz.bar.com', RecordType.A, 'Complete',
                                 'id2', 'system-message', 'rchangeid2', 'rsid2')
     bc = BatchChange('user-id', 'user-name', 'batch change test', datetime.utcnow(), [arc, drc],
@@ -71,8 +71,9 @@ def test_create_batch_change(mocked_responses, vinyldns_client):
 
 
 def test_get_batch_change(mocked_responses, vinyldns_client):
-    arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, 200, AData('1.2.3.4'),
-                          'Complete', 'id1', 'system-message', 'rchangeid1', 'rsid1')
+    arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, 200,
+                          AData('1.2.3.4'), 'Complete', 'id1', 'system-message', 'rchangeid1', 'rsid1')
+
     drc = DeleteRecordSetChange(forward_zone.id, forward_zone.name, 'baz', 'baz.bar.com', RecordType.A, 'Complete',
                                 'id2', 'system-message', 'rchangeid2', 'rsid2')
     bc = BatchChange('user-id', 'user-name', 'batch change test', datetime.utcnow(), [arc, drc],

--- a/tests/test_batch_change.py
+++ b/tests/test_batch_change.py
@@ -16,8 +16,8 @@ from datetime import datetime
 
 import responses
 from sampledata import forward_zone
-from vinyldns.record import RecordType
-from vinyldns.serdes import to_json_string
+from vinyldns.record import RecordType, AData
+from vinyldns.serdes import to_json_string, to_dict
 from vinyldns.batch_change import AddRecordChange, DeleteRecordSetChange, BatchChange, BatchChangeRequest, \
     DeleteRecordSet, AddRecord, BatchChangeSummary, ListBatchChangeSummaries
 
@@ -39,15 +39,17 @@ def check_single_changes_are_same(a, b):
 
 
 def test_create_batch_change(mocked_responses, vinyldns_client):
-    ar = AddRecord('foo.bar.com', RecordType.A, 100, '1.2.3.4')
+    ar = AddRecord('foo.bar.com', RecordType.A, 100, AData('1.2.3.4'))
     drs = DeleteRecordSet('baz.bar.com', RecordType.A)
 
-    arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, '1.2.3.4',
+    arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, 200, AData('1.2.3.4'),
                           'Complete', 'id1', 'system-message', 'rchangeid1', 'rsid1')
+                          
     drc = DeleteRecordSetChange(forward_zone.id, forward_zone.name, 'baz', 'baz.bar.com', RecordType.A, 'Complete',
                                 'id2', 'system-message', 'rchangeid2', 'rsid2')
     bc = BatchChange('user-id', 'user-name', 'batch change test', datetime.utcnow(), [arc, drc],
                      'bcid', 'owner-group-id')
+
     mocked_responses.add(
         responses.POST, 'http://test.com/zones/batchrecordchanges',
         body=to_json_string(bc), status=200
@@ -69,7 +71,7 @@ def test_create_batch_change(mocked_responses, vinyldns_client):
 
 
 def test_get_batch_change(mocked_responses, vinyldns_client):
-    arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, '1.2.3.4',
+    arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, 200, AData('1.2.3.4'),
                           'Complete', 'id1', 'system-message', 'rchangeid1', 'rsid1')
     drc = DeleteRecordSetChange(forward_zone.id, forward_zone.name, 'baz', 'baz.bar.com', RecordType.A, 'Complete',
                                 'id2', 'system-message', 'rchangeid2', 'rsid2')

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -88,9 +88,10 @@ def test_delete_record_set(record_set, mocked_responses, vinyldns_client):
 def test_get_record_set(record_set, mocked_responses, vinyldns_client):
     rs = copy.deepcopy(record_set)
     rs.id = rs.name + 'id'
+    response = {'recordSet': rs}
     mocked_responses.add(
         responses.GET, 'http://test.com/zones/{0}/recordsets/{1}'.format(rs.zone_id, rs.id),
-        body=to_json_string(rs), status=200
+        body=to_json_string(response), status=200
     )
     r = vinyldns_client.get_record_set(rs.zone_id, rs.id)
     check_record_sets_are_equal(rs, r)


### PR DESCRIPTION
Fixes #51  There was an issue with how we serialized:

1. we were looking for a field named `recordData`, when it was just `record`
2. during deserialization, we were not converting the `record` properly using the `rdata_converter`
3. Also fixed #50, as it was a small serialization issue as well