### PR TITLE
push to upstream master not origin

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -90,8 +90,8 @@ twine upload ${RELEASE_URL} ${DIR}/dist/*
 
 if [[ "$GIT_PUSH" == "true" ]]; then
     echo "Pushing git tags..."
-    git push
-    git push --tags
+    git push upstream master
+    git push upstream master --tags
 else
     echo "Skipping push to git!"
 fi


### PR DESCRIPTION
this is risky, hard to tell the right way to go about this in a more safe way (probably want to at least check youre not way off of upstream??)

in either case, the script as is with git push is annoying, you then have to backtrack in the case you are working from a fork (which we generally are)