### PR TITLE
Support optional record data field for DeleteRecordSet

### DIFF
--- a/src/vinyldns/batch_change.py
+++ b/src/vinyldns/batch_change.py
@@ -59,10 +59,13 @@ class DeleteRecordSet(object):
 
     @staticmethod
     def from_dict(d):
+        record = d.get('record')
+        if record is not None:
+            record = rdata_converters[d['type']](record)
         return DeleteRecordSet(
             input_name=d['inputName'],
             type=d['type'],
-            record=d.get('record')
+            record=record
         )
 
 
@@ -160,13 +163,16 @@ class DeleteRecordSetChange(object):
 
     @staticmethod
     def from_dict(d):
+        record = d.get('record')
+        if record is not None:
+            record = rdata_converters[d['type']](record)
         return DeleteRecordSetChange(
             zone_id=d['zoneId'],
             zone_name=d['zoneName'],
             record_name=d['recordName'],
             input_name=d['inputName'],
             type=d['type'],
-            record=d.get('record'),
+            record=record,
             status=d['status'],
             id=d['id'],
             system_message=d.get('systemMessage'),

--- a/src/vinyldns/batch_change.py
+++ b/src/vinyldns/batch_change.py
@@ -51,16 +51,18 @@ class AddRecord(object):
 
 
 class DeleteRecordSet(object):
-    def __init__(self, input_name, type):
+    def __init__(self, input_name, type, record=None):
         self.input_name = input_name
         self.type = type
+        self.record = record
         self.change_type = 'DeleteRecordSet'
 
     @staticmethod
     def from_dict(d):
         return DeleteRecordSet(
             input_name=d['inputName'],
-            type=d['type']
+            type=d['type'],
+            record=d.get('record')
         )
 
 
@@ -141,12 +143,13 @@ class AddRecordChange(object):
 
 class DeleteRecordSetChange(object):
     def __init__(self, zone_id, zone_name, record_name, input_name, type, status,
-                 id, validation_errors, system_message=None, record_change_id=None, record_set_id=None):
+                 id, validation_errors, system_message=None, record_change_id=None, record_set_id=None, record=None):
         self.zone_id = zone_id
         self.zone_name = zone_name
         self.record_name = record_name
         self.input_name = input_name
         self.type = type
+        self.record = record
         self.status = status
         self.id = id
         self.system_message = system_message
@@ -163,6 +166,7 @@ class DeleteRecordSetChange(object):
             record_name=d['recordName'],
             input_name=d['inputName'],
             type=d['type'],
+            record=d.get('record'),
             status=d['status'],
             id=d['id'],
             system_message=d.get('systemMessage'),

--- a/src/vinyldns/batch_change.py
+++ b/src/vinyldns/batch_change.py
@@ -59,13 +59,10 @@ class DeleteRecordSet(object):
 
     @staticmethod
     def from_dict(d):
-        record = d.get('record')
-        if record is not None:
-            record = rdata_converters[d['type']](record)
         return DeleteRecordSet(
             input_name=d['inputName'],
             type=d['type'],
-            record=record
+            record=map_option(d.get('record'), rdata_converters[d['type']])
         )
 
 
@@ -163,16 +160,13 @@ class DeleteRecordSetChange(object):
 
     @staticmethod
     def from_dict(d):
-        record = d.get('record')
-        if record is not None:
-            record = rdata_converters[d['type']](record)
         return DeleteRecordSetChange(
             zone_id=d['zoneId'],
             zone_name=d['zoneName'],
             record_name=d['recordName'],
             input_name=d['inputName'],
             type=d['type'],
-            record=record,
+            record=map_option(d.get('record'), rdata_converters[d['type']]),
             status=d['status'],
             id=d['id'],
             system_message=d.get('systemMessage'),

--- a/tests/test_batch_change.py
+++ b/tests/test_batch_change.py
@@ -70,6 +70,7 @@ def check_batch_changes_are_same(a, b):
 def test_create_batch_change(mocked_responses, vinyldns_client):
     ar = AddRecord('foo.baa.com', RecordType.A, 100, AData('1.2.3.4'))
     drs = DeleteRecordSet('baz.bar.com', RecordType.A)
+    drs_with_data = DeleteRecordSet('baz-with-data.bar.com', RecordType.A, AData('5.6.7.8'))
 
     arc = AddRecordChange(forward_zone.id, forward_zone.name, 'foo', 'foo.bar.com', RecordType.A, 200,
                           AData('1.2.3.4'), 'Complete', 'id1', [], 'system-message', 'rchangeid1', 'rsid1')
@@ -77,13 +78,17 @@ def test_create_batch_change(mocked_responses, vinyldns_client):
     drc = DeleteRecordSetChange(forward_zone.id, forward_zone.name, 'baz', 'baz.bar.com', RecordType.A, 'Complete',
                                 'id2', [], 'system-message', 'rchangeid2', 'rsid2')
 
+    drc_with_data = DeleteRecordSetChange(forward_zone.id, forward_zone.name, 'baz-with-data', 'baz-with-data.bar.com',
+                                          RecordType.A, 'Complete', 'id2', [], 'system-message', 'rchangeid3', 'rsid3',
+                                          AData('5.6.7.8'))
+
     # Python 2/3 compatibility
     try:
         tomorrow = datetime.now().astimezone() + timedelta(1)
     except TypeError:
         tomorrow = datetime.now(tzlocal()).astimezone(tzlocal()) + timedelta(1)
 
-    bc = BatchChange('user-id', 'user-name', datetime.utcnow(), [arc, drc],
+    bc = BatchChange('user-id', 'user-name', datetime.utcnow(), [arc, drc, drc_with_data],
                      'bcid', 'Scheduled', 'PendingReview',
                      comments='batch change test', owner_group_id='owner-group-id',
                      scheduled_time=tomorrow)
@@ -95,7 +100,7 @@ def test_create_batch_change(mocked_responses, vinyldns_client):
 
     r = vinyldns_client.create_batch_change(
         BatchChangeRequest(
-            changes=[ar, drs],
+            changes=[ar, drs, drs_with_data],
             comments='batch change test',
             owner_group_id='owner-group-id',
             scheduled_time=tomorrow

--- a/tests/test_batch_change.py
+++ b/tests/test_batch_change.py
@@ -118,7 +118,11 @@ def test_get_batch_change(mocked_responses, vinyldns_client):
                                 'baz.bar.com', RecordType.A, 'Complete',
                                 'id2', [], 'system-message', 'rchangeid2', 'rsid2')
 
-    bc = BatchChange('user-id', 'user-name', datetime.utcnow(), [arc, drc],
+    drc_with_data = DeleteRecordSetChange(forward_zone.id, forward_zone.name, 'biz',
+                                          'biz.bar.com', RecordType.A, 'Complete',
+                                          'id3', [], 'system-message', 'rchangeid3', 'rsid3', AData("5.6.7.8"))
+
+    bc = BatchChange('user-id', 'user-name', datetime.utcnow(), [arc, drc, drc_with_data],
                      'bcid', 'Complete', 'AutoApproved',
                      comments='batch change test', owner_group_id='owner-group-id')
 


### PR DESCRIPTION
As part of the multi-record initiative in the VinylDNS API, we need to support optional `record` data in `DeleteRecordSet`.

Changes in this PR:
- Support optional `record` for `DeleteRecordSet` input and serialization
- Update unit test

------
Tested locally against API with multi-record enabled:
```
>>> from vinyldns.client import VinylDNSClient
>>> local_client = VinylDNSClient("http://localhost:9000", "testUserAccessKey", "testUserSecretKey")
>>> from vinyldns.serdes import *
>>> from vinyldns.batch_change import *
>>> req = BatchChangeRequest([DeleteRecordSet('python-delete.dummy.', 'A', {'address': '1.2.3.4'}), DeleteRecordSet('python-delete-no-data', 'A')], 'python delete record set with data', 'another-global-acl-group')
>>> to_json_string(local_client.create_batch_change(req))
'{"userId": "testuser", "userName": "testuser", "comments": "python delete record set with data", "createdTimestamp": "2019-10-10T16:17:46+00:00", "changes": [{"zoneId": "", "zoneName": "", "recordName": "", "inputName": "python-delete.dummy.", "type": "A", "record": {"address": "1.2.3.4"}, "status": "NeedsReview", "id": "21b5399c-ca14-4657-8daf-2354e87fbb46", "systemMessage": null, "recordChangeId": null, "recordSetId": null, "changeType": "DeleteRecordSet", "validationErrors": [{"errorType": "ZoneDiscoveryError", "message": "Zone Discovery Failed: zone for \\"python-delete.dummy.\\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS."}]}, {"zoneId": "", "zoneName": "", "recordName": "", "inputName": "python-delete-no-data.", "type": "A", "record": null, "status": "NeedsReview", "id": "07935e94-77ce-460c-9be2-ce8df8602269", "systemMessage": null, "recordChangeId": null, "recordSetId": null, "changeType": "DeleteRecordSet", "validationErrors": [{"errorType": "ZoneDiscoveryError", "message": "Zone Discovery Failed: zone for \\"python-delete-no-data.\\" does not exist in VinylDNS. If zone exists, then it must be connected to in VinylDNS."}]}], "id": "1c9f1383-fae9-4467-a887-4f2d51b4efbe", "status": "PendingReview", "ownerGroupId": "another-global-acl-group", "ownerGroupName": null, "approvalStatus": "PendingReview", "reviewerId": null, "reviewerUserName": null, "reviewComment": null, "reviewTimestamp": null, "scheduledTime": null}'
```