### PR TITLE
client.py: Add endpoint for cancel_batch_change()

### DIFF
--- a/func_tests/test_client.py
+++ b/func_tests/test_client.py
@@ -98,6 +98,26 @@ def test_batch_change_review_process_reject(vinyldns_test_context):
     assert completed_bc.review_comment == 'cannot create the zone'
 
 
+def test_batch_change_review_process_cancel(vinyldns_test_context):
+    changes = [
+        AddRecord('test-approve-success.not.loaded.', RecordType.A, 200,
+                  AData("4.3.2.1"))
+    ]
+
+    bc = vinyldns_test_context.client.create_batch_change(
+        BatchChangeRequest(changes, 'comments', vinyldns_test_context.group.id)
+    )
+
+    assert bc.status == 'PendingReview'
+    assert bc.approval_status == 'PendingReview'
+    assert len(bc.changes[0].validation_errors) == 1
+
+    cancelled_bc = vinyldns_test_context.client.cancel_batch_change(bc.id)
+
+    assert cancelled_bc.status == 'Cancelled'
+    assert cancelled_bc.approval_status == 'Cancelled'
+
+
 def test_batch_change_review_process_approve(vinyldns_test_context):
     approver = vinyldns_test_context.support_client
 

--- a/src/vinyldns/client.py
+++ b/src/vinyldns/client.py
@@ -663,6 +663,17 @@ class VinylDNSClient(object):
 
         return BatchChange.from_dict(data)
 
+    def cancel_batch_change(self, batch_change_id, **kwargs):
+        """
+        Cancel a batch change
+
+        :return: the content of the response
+        """
+        url = urljoin(self.index_url, u'/zones/batchrecordchanges/{0}/cancel'.format(batch_change_id))
+        response, data = self.__make_request(url, u'POST', self.headers, **kwargs)
+
+        return BatchChange.from_dict(data) if data is not None else None
+
     def reject_batch_change(self, batch_change_id, rejection=None, **kwargs):
         """
         Reject a batch change


### PR DESCRIPTION
This commit adds the support for cancelling a
given batch change, provided with a batch_change_id.

Closes https://github.com/vinyldns/vinyldns-python/issues/61