### PR TITLE
Fix flake8 errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,8 @@ commands =
 [testenv:check]
 deps =
     docutils
-    flake8
+    flake8==3.7.9
+
 skip_install = true
 commands =
     flake8 src tests setup.py


### PR DESCRIPTION
Update flake8 to use specific version for deterministic build

Ultimately we can fix the reported issues if/when we upgrade flake.  The build error only showed up because we didn't lock in on a version.

Fixes #68 