### PR TITLE
Bump version: 0.9.5 -> 0.9.6 [ci skip]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.4
+current_version = 0.9.6
 tag = True
 commit = True
 message = Bump version: {current_version} -> {new_version} [ci skip]
@@ -27,4 +27,3 @@ addopts =
 	--doctest-modules
 	--doctest-glob=\*.rst
 	--tb=short
-

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ with open('README.md') as f:
 setup(
     cmdclass={'test': PyTest},
     name='vinyldns-python',
-    version='0.9.4',
+    version='0.9.6',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],


### PR DESCRIPTION
The deployed version was 0.9.5, but our `setup.cfg` and `setup.py` were not updated apparently with the last push to `PyPi`.  `0.9.6` is the latest version.