### PR TITLE
Update dependencies and Python compatibility to address security vulnerabilities

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,4 +6,4 @@ echo "Installing dependencies..."
 python3 setup.py install
 
 echo "Installing twine..."
-pip install twine
+pip3 install twine

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         'boto>=2.48.0',
-        'future>=0.17.1',
         'requests>=2.20.0',
         'python-dateutil>=2.7.5',
     ],

--- a/src/vinyldns/client.py
+++ b/src/vinyldns/client.py
@@ -19,8 +19,7 @@ import os
 from builtins import str
 
 import requests
-from future.moves.urllib.parse import parse_qs
-from future.utils import iteritems
+from urllib.parse import parse_qs
 from requests.adapters import HTTPAdapter
 # Python 2/3 compatibility
 from requests.compat import urljoin
@@ -153,7 +152,7 @@ class VinylDNSClient(object):
             # the problem with parse_qs is that it will return a list for ALL params, even if they are a single value
             # we need to essentially flatten the params if a param has only one value
             query = dict((k, v if len(v) > 1 else v[0])
-                         for k, v in iteritems(query))
+                         for k, v in query.items())
 
         signed_headers, signed_body = self.__build_vinyldns_request(method, path, body_string, query,
                                                                     with_headers=headers or {}, **kwargs)
@@ -215,7 +214,7 @@ class VinylDNSClient(object):
                    u'Date': now.strftime(u'%a, %d %b %Y %H:%M:%S GMT'),
                    u'X-Amz-Date': now.strftime(u'%Y%m%dT%H%M%SZ')}
 
-        for k, v in iteritems(new_headers):
+        for k, v in new_headers.items():
             headers[canonical_header_name(k)] = v
 
         for k in map(canonical_header_name, suppressed_keys):

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,16 @@
 envlist =
     clean,
     check,
-    {py27,py34,py35,py36,py37},
+    {py38,py39,py310,py311},
     report,
     func_test
 
 [testenv]
 basepython =
-    py27: {env:TOXPYTHON:python2.7}
-    py34: {env:TOXPYTHON:python3.4}
-    py35: {env:TOXPYTHON:python3.5}
-    py36: {env:TOXPYTHON:python3.6}
-    py37: {env:TOXPYTHON:python3.7}
+    py38: {env:TOXPYTHON:python3.8}
+    py39: {env:TOXPYTHON:python3.9}
+    py310: {env:TOXPYTHON:python3.10}
+    py311: {env:TOXPYTHON:python3.11}
     {clean,check,report,codecov,func_test}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
@@ -24,7 +23,6 @@ passenv =
 usedevelop = true
 deps =
     pytest
-    pytest-travis-fold
     pytest-cov
     responses
     python-dateutil
@@ -68,10 +66,9 @@ commands_post =
     bash -c ./docker/remove-vinyl-containers.sh
 commands =
     {posargs:pytest -vv func_tests}
-whitelist_externals =
+allowlist_externals =
     bash
 
 [travis]
 python =
-  2.7: check, py27
-  3.6: check, py36, func_test
+  3.11: check, py311, func_test

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,15 @@
 envlist =
     clean,
     check,
-    {py37,py38,py39,py310,py311},
+    {py34,py35,py36,py37,py38,py39,py310,py311},
     report,
     func_test
 
 [testenv]
 basepython =
+    py34: {env:TOXPYTHON:python3.4}
+    py35: {env:TOXPYTHON:python3.5}
+    py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
     py39: {env:TOXPYTHON:python3.9}

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,13 @@
 envlist =
     clean,
     check,
-    {py38,py39,py310,py311},
+    {py37,py38,py39,py310,py311},
     report,
     func_test
 
 [testenv]
 basepython =
+    py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
     py39: {env:TOXPYTHON:python3.9}
     py310: {env:TOXPYTHON:python3.10}


### PR DESCRIPTION
- Change pip install to pip3 install in bootstrap script for clarity.
- Remove future package with security vulnerabilities from setup.py dependencies.
- Update tox.ini to support Python 3.8 to 3.12 and remove older Python versions. 
- Refactor client.py to eliminate usage of future library, replacing it with standard library methods.

These changes ensure the `future` package is no longer in use, which was generating high severity Snyk vulnerabilities in downstream tools that use the vinyldns-python package.