### PR TITLE
Add pre-commit hook to verify required apache headers

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          pip install tox pre-commit
 
       - name: Run tests
-        run: tox -e check,py3
+        run: |
+          tox -e check,py3
+          pre-commit run apache-license-header-check --all-files
 
       - name: Upload coverage to Codecov
         if: success()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+
+repos:
+    - repo: local
+      hooks:
+          - id: apache-license-header-check
+            name: apache license header check
+            entry: python3 scripts/apache_header_check.py
+            language: system
+            types: [python]
+            pass_filenames: true
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-
 repos:
     - repo: local
       hooks:
@@ -8,4 +7,3 @@ repos:
             language: system
             types: [python]
             pass_filenames: true
-

--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ To run, `pip install vinyldns-python` and then:
 * `python3`
 * `pip`
 * `virtualenv`
+* `pre-commit`
 
 To get started, you will want to setup your virtual environment.
 
 1. Ensure that you have `virtualenv` installed `> pip install virtualenv`
 1. Run `./bootstrap.sh` to setup your environment (unless you really want all these dependencies to be installed locally, which we do not recommend).
-1. Activate your virtual environment `> source .virtualenv/bin/activate` and you will be ready to go!
+1. Activate your virtual environment `> source .virtualenv/bin/activate`
+2. Install pre-commit so you can enable any pre-commit hooks > `pip install pre-commit`
+3. Enable the pre-commit hooks `> pre-commit install`. If installed correctly, you should see the following output: pre-commit installed at .git/hooks/pre-commit
 
 **Unit Tests**
 
@@ -62,6 +65,8 @@ If you see any failures / warnings, correct them until `tox` runs successfully.
 
 If you do not have `tox` in your environment, `pip install tox` to add it.  For more information you can
 read the [tox docs](https://tox.readthedocs.io/en/latest/index.html).
+
+You will also want to run the apache pre-commit hook check to make sure no files are missing the license before pushing code. To do this run `pre-commit run apache-license-header-check --all-files`
 
 ## Local Development
 See the [quickstart](https://github.com/vinyldns/vinyldns/blob/master/README.md#quickstart) in the

--- a/func_tests/test_client.py
+++ b/func_tests/test_client.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from func_tests.vinyldns_context import vinyldns_test_context
 from vinyldns.batch_change import AddRecordChange, DeleteRecordSetChange, BatchChange, BatchChangeRequest, \
     DeleteRecordSet, AddRecord, BatchChangeSummary, ListBatchChangeSummaries

--- a/func_tests/utils.py
+++ b/func_tests/utils.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 import time
 import logging

--- a/func_tests/vinyldns_context.py
+++ b/func_tests/vinyldns_context.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import sys
 sys.path.append('../')
 sys.path.append('./')

--- a/scripts/apache_header_check.py
+++ b/scripts/apache_header_check.py
@@ -37,7 +37,7 @@ def license_crosscheck(file_path, license_to_check, copyright_pattern):
 
         #if the boiler text exists, the first 10 comment tokens will always be the license tokens
 
-        if license_tokens[1:10] == license_to_check and copyright_pattern.fullmatch(license_tokens[0]):
+        if len(license_tokens) >= 10 and license_tokens[1:10] == license_to_check and copyright_pattern.fullmatch(license_tokens[0]):
             return True
         else:
             return False

--- a/scripts/apache_header_check.py
+++ b/scripts/apache_header_check.py
@@ -11,34 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
 import sys
 import tokenize
 
-license_to_check_18 = ['Copyright 2018 Comcast Cable Communications Management, LLC',
-                       'Licensed under the Apache License, Version 2.0 (the "License");',
-                       'you may not use this file except in compliance with the License.',
-                       'You may obtain a copy of the License at', '    http://www.apache.org/licenses/LICENSE-2.0',
-                       'Unless required by applicable law or agreed to in writing, software',
-                       'distributed under the License is distributed on an "AS IS" BASIS,',
-                       'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
-                       'See the License for the specific language governing permissions and',
-                       'limitations under the License.']
-license_to_check_26 = ['Copyright 2026 Comcast Cable Communications Management, LLC',
-                       'Licensed under the Apache License, Version 2.0 (the "License");',
-                       'you may not use this file except in compliance with the License.',
-                       'You may obtain a copy of the License at', '    http://www.apache.org/licenses/LICENSE-2.0',
-                       'Unless required by applicable law or agreed to in writing, software',
-                       'distributed under the License is distributed on an "AS IS" BASIS,',
-                       'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
-                       'See the License for the specific language governing permissions and',
-                       'limitations under the License.']
-
+copyright_pattern = re.compile(r"Copyright \d{4} Comcast Cable Communications Management, LLC")
+license_to_check = ['Licensed under the Apache License, Version 2.0 (the "License");','you may not use this file except in compliance with the License.','You may obtain a copy of the License at', '    http://www.apache.org/licenses/LICENSE-2.0','Unless required by applicable law or agreed to in writing, software','distributed under the License is distributed on an "AS IS" BASIS,','WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.','See the License for the specific language governing permissions and','limitations under the License.']
 missing_license = False
 
 
 #checks if the license_to_check is in a comment in the files
-def license_crosscheck(file_path, license_to_check_18, license_to_check_26):
+def license_crosscheck(file_path, license_to_check, copyright_pattern):
     with tokenize.open(file_path) as file:
         # this list will have all the comments tokens in the file
         license_tokens = []
@@ -54,7 +37,7 @@ def license_crosscheck(file_path, license_to_check_18, license_to_check_26):
 
         #if the boiler text exists, the first 10 comment tokens will always be the license tokens
 
-        if license_tokens[:10] == license_to_check_18 or license_tokens[:10] == license_to_check_26:
+        if license_tokens[1:10] == license_to_check and copyright_pattern.fullmatch(license_tokens[0]):
             return True
         else:
             return False
@@ -65,7 +48,7 @@ for filepath in sys.argv[1:]:
     with open(filepath, "r", encoding="utf-8") as f:
 
         #check if the first 10 comment tokens in the file match the licenses list for either 2018 or 2026 copyright boiler text
-        if not license_crosscheck(filepath, license_to_check_18, license_to_check_26):
+        if not license_crosscheck(filepath, license_to_check, copyright_pattern):
             print(f"Error: Missing Apache License header in {filepath}")
             missing_license = True
 

--- a/scripts/apache_header_check.py
+++ b/scripts/apache_header_check.py
@@ -11,40 +11,61 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import sys
 import tokenize
 
-license_to_check ='''Licensed under the Apache License, Version 2.0 (the "License");'''
-'''you may not use this file except in compliance with the License.'''
-'''You may obtain a copy of the License at'''
-'''http://www.apache.org/licenses/LICENSE-2.0'''
-'''Unless required by applicable law or agreed to in writing, software'''
-'''distributed under the License is distributed on an "AS IS" BASIS,'''
-'''WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.'''
-'''See the License for the specific language governing permissions and'''
-'''limitations under the License.'''
+license_to_check_18 = ['Copyright 2018 Comcast Cable Communications Management, LLC',
+                       'Licensed under the Apache License, Version 2.0 (the "License");',
+                       'you may not use this file except in compliance with the License.',
+                       'You may obtain a copy of the License at', '    http://www.apache.org/licenses/LICENSE-2.0',
+                       'Unless required by applicable law or agreed to in writing, software',
+                       'distributed under the License is distributed on an "AS IS" BASIS,',
+                       'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
+                       'See the License for the specific language governing permissions and',
+                       'limitations under the License.']
+license_to_check_26 = ['Copyright 2026 Comcast Cable Communications Management, LLC',
+                       'Licensed under the Apache License, Version 2.0 (the "License");',
+                       'you may not use this file except in compliance with the License.',
+                       'You may obtain a copy of the License at', '    http://www.apache.org/licenses/LICENSE-2.0',
+                       'Unless required by applicable law or agreed to in writing, software',
+                       'distributed under the License is distributed on an "AS IS" BASIS,',
+                       'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
+                       'See the License for the specific language governing permissions and',
+                       'limitations under the License.']
 
 missing_license = False
 
 
 #checks if the license_to_check is in a comment in the files
-def is_string_in_comment(file_path, target_string):
+def license_crosscheck(file_path, license_to_check_18, license_to_check_26):
     with tokenize.open(file_path) as file:
+        # this list will have all the comments tokens in the file
+        license_tokens = []
+
         # Loop through every token in the Python file
         for token in tokenize.generate_tokens(file.readline):
+
             # Check if the current token is a comment
             if token.type == tokenize.COMMENT:
-                # Check if apache link string is inside that comment
-                if target_string in token.string:
-                    return True
-        return False
+                if token.string.startswith("# "):
+                    #add the comment to the license_tokens list, removing the leading "# " from the comment
+                    license_tokens.append(token.string[2:])
+
+        #if the boiler text exists, the first 10 comment tokens will always be the license tokens
+
+        if license_tokens[:10] == license_to_check_18 or license_tokens[:10] == license_to_check_26:
+            return True
+        else:
+            return False
+
 
 #Iterate through the .py files passed by the .pre-commit-config.yaml file
 for filepath in sys.argv[1:]:
     with open(filepath, "r", encoding="utf-8") as f:
 
-        #if license is not in header print it out in the pre commit error
-        if not is_string_in_comment(filepath, license_to_check):
+        #check if the first 10 comment tokens in the file match the licenses list for either 2018 or 2026 copyright boiler text
+        if not license_crosscheck(filepath, license_to_check_18, license_to_check_26):
             print(f"Error: Missing Apache License header in {filepath}")
             missing_license = True
 

--- a/scripts/apache_header_check.py
+++ b/scripts/apache_header_check.py
@@ -1,0 +1,43 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import tokenize
+
+license_to_check =  "http://www.apache.org/licenses/LICENSE-2.0"
+
+missing_license = False
+
+#checks if the license_to_check is in a comment in the files
+def is_string_in_comment(file_path, target_string):
+    with tokenize.open(file_path) as file:
+        # Loop through every token in the Python file
+        for token in tokenize.generate_tokens(file.readline):
+            # Check if the current token is a comment
+            if token.type == tokenize.COMMENT:
+                # Check if apache link string is inside that comment
+                if target_string in token.string:
+                    return True
+    return False
+
+#Iterate through the .py files passed by the .pre-commit-config.yaml file
+for filepath in sys.argv[1:]:
+    with open(filepath, "r", encoding="utf-8") as f:
+
+        #if license is not in header print it out in the pre commit error
+        if not is_string_in_comment(filepath, license_to_check):
+            print(f"Error: Missing Apache License header in {filepath}")
+            missing_license = True
+
+if missing_license:
+    sys.exit(1)

--- a/scripts/apache_header_check.py
+++ b/scripts/apache_header_check.py
@@ -14,9 +14,18 @@
 import sys
 import tokenize
 
-license_to_check =  "http://www.apache.org/licenses/LICENSE-2.0"
+license_to_check ='''Licensed under the Apache License, Version 2.0 (the "License");'''
+'''you may not use this file except in compliance with the License.'''
+'''You may obtain a copy of the License at'''
+'''http://www.apache.org/licenses/LICENSE-2.0'''
+'''Unless required by applicable law or agreed to in writing, software'''
+'''distributed under the License is distributed on an "AS IS" BASIS,'''
+'''WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.'''
+'''See the License for the specific language governing permissions and'''
+'''limitations under the License.'''
 
 missing_license = False
+
 
 #checks if the license_to_check is in a comment in the files
 def is_string_in_comment(file_path, target_string):
@@ -28,7 +37,7 @@ def is_string_in_comment(file_path, target_string):
                 # Check if apache link string is inside that comment
                 if target_string in token.string:
                     return True
-    return False
+        return False
 
 #Iterate through the .py files passed by the .pre-commit-config.yaml file
 for filepath in sys.argv[1:]:

--- a/scripts/search_records_by_name.py
+++ b/scripts/search_records_by_name.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import argparse
 import csv
 import logging

--- a/scripts/search_records_by_owner_group.py
+++ b/scripts/search_records_by_owner_group.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import argparse
 import csv
 import logging

--- a/scripts/update_record_owner.py
+++ b/scripts/update_record_owner.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import argparse
 import csv
 import logging

--- a/scripts/zone_dump.py
+++ b/scripts/zone_dump.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import argparse
 import csv
 import logging


### PR DESCRIPTION
Closes issue #7 
VDNS-427

Problem: Needed a way to automatically check that the apache license header exists in all relevant files to ensure it does not accidentally get left out from future commits to any relevant source files.

Approach: I implemented a pre-commit hook (.pre-commit-config.yaml) that calls a small python script (scripts/apache_header_check.py). The script checks all ‘.py’ files in the repo to see if the license boiler text exists in the comments of each file. If it does not, it fails and lets you know which file is missing it. I did not check the full copyright text as I noticed the copyright year isn’t always 2018 , so I only checked ‘http://www.apache.org/licenses/LICENSE-2.0', but can rework to include full copyright text check if needed.

Validation: You can test this by choosing a current ‘.py’ file that has the boiler plate text and removing it. When you go to commit the file, it will error out and let you know that the file is missing the boiler plate text. If you re-add the license information and re-commit it will pass. You can also manually run the command in the terminal with: pre-commit run apache-license-header-check --all-files 