### PR TITLE
Issue 52 record update payload - VDNS-428

### DIFF
--- a/src/vinyldns/client.py
+++ b/src/vinyldns/client.py
@@ -603,7 +603,6 @@ class VinylDNSClient(object):
         """
         url = urljoin(self.index_url, u'/zones/{0}/recordsets/{1}'.format(record_set.zone_id, record_set.id))
 
-        #update payload object to remove unnecessary fields such as status, created, updated, fqdn
         payload = self._record_set_update_payload(record_set)
         response, data = self.__make_request(url, u'PUT', self.headers,
                                              to_json_string(payload), **kwargs)

--- a/src/vinyldns/client.py
+++ b/src/vinyldns/client.py
@@ -596,17 +596,38 @@ class VinylDNSClient(object):
 
     def update_record_set(self, record_set, **kwargs):
         """
-        Delete an existing record_set.
+        Update an existing record_set.
 
         :param record_set: the record_set to be updated
         :return: the content of the response
         """
         url = urljoin(self.index_url, u'/zones/{0}/recordsets/{1}'.format(record_set.zone_id, record_set.id))
 
+        #update payload object to remove unnecessary fields such as status, created, updated, fqdn
+        payload = self._record_set_update_payload(record_set)
         response, data = self.__make_request(url, u'PUT', self.headers,
-                                             to_json_string(record_set), **kwargs)
+                                             to_json_string(payload), **kwargs)
 
         return RecordSetChange.from_dict(data)
+
+    @staticmethod
+    def _record_set_update_payload(record_set):
+        payload = {
+            "zoneId": record_set.zone_id,
+            "id": record_set.id,
+            "name": record_set.name,
+            "type": record_set.type,
+            "ttl": record_set.ttl,
+            "records": record_set.records,
+        }
+
+        if record_set.owner_group_id is not None:
+            payload["ownerGroupId"] = record_set.owner_group_id
+
+        if record_set.record_set_group_change is not None:
+            payload["recordSetGroupChange"] = record_set.record_set_group_change
+
+        return payload
 
     def get_record_set(self, zone_id, rs_id, **kwargs):
         """

--- a/src/vinyldns/record.py
+++ b/src/vinyldns/record.py
@@ -227,7 +227,6 @@ class RecordSet(object):
             status=d.get('status'),
             created=map_option(d.get('created'), parse_datetime),
             updated=d.get('updated'),
-            # updated=map_option(d.get('updated'), parse_datetime),
             records=[rdata_converters[d['type']](rd) for rd in d.get('records', [])],
             id=d.get('id'),
             owner_group_id=d.get('ownerGroupId'),

--- a/src/vinyldns/record.py
+++ b/src/vinyldns/record.py
@@ -227,6 +227,7 @@ class RecordSet(object):
             status=d.get('status'),
             created=map_option(d.get('created'), parse_datetime),
             updated=d.get('updated'),
+            # updated=map_option(d.get('updated'), parse_datetime),
             records=[rdata_converters[d['type']](rd) for rd in d.get('records', [])],
             id=d.get('id'),
             owner_group_id=d.get('ownerGroupId'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """TODO: Add module docstring."""
+import copy
 
 import pytest
 import responses
-from sampledata import record_set_values
+from sampledata import record_set_values, record_sets
 from vinyldns.client import VinylDNSClient
+
+from vinyldns.record import RecordType
 
 
 def get_rs_type(rs):
@@ -37,3 +40,7 @@ def mocked_responses():
 @pytest.fixture(scope="module")
 def vinyldns_client():
     return VinylDNSClient('http://test.com', 'ok', 'ok')
+
+@pytest.fixture
+def txt_record_set():
+    return copy.deepcopy(record_sets[RecordType.TXT])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 """TODO: Add module docstring."""
 import copy
-
 import pytest
 import responses
 from sampledata import record_set_values, record_sets
 from vinyldns.client import VinylDNSClient
-
 from vinyldns.record import RecordType
 
 
@@ -40,6 +38,7 @@ def mocked_responses():
 @pytest.fixture(scope="module")
 def vinyldns_client():
     return VinylDNSClient('http://test.com', 'ok', 'ok')
+
 
 @pytest.fixture
 def txt_record_set():

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -14,13 +14,10 @@
 
 import copy
 import json
-
 import responses
 from sampledata import record_sets, record_set_values, gen_rs_change, forward_zone
-from vinyldns.record import RecordSet, RecordSetChange, ListRecordSetsResponse, ListRecordSetChangesResponse
-from vinyldns.serdes import to_json_string, from_json_string
-from vinyldns.serdes import parse_datetime
-from vinyldns.record import RecordSetStatus
+from vinyldns.record import RecordSet, RecordSetChange, ListRecordSetsResponse, ListRecordSetChangesResponse, RecordSetStatus
+from vinyldns.serdes import to_json_string, from_json_string, parse_datetime
 
 
 def check_record_sets_are_equal(a, b):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import copy
+import json
 
 import responses
 from sampledata import record_sets, record_set_values, gen_rs_change, forward_zone
 from vinyldns.record import RecordSet, RecordSetChange, ListRecordSetsResponse, ListRecordSetChangesResponse
 from vinyldns.serdes import to_json_string, from_json_string
-
 from vinyldns.serdes import parse_datetime
 
 
@@ -74,24 +74,44 @@ def test_update_record_set(record_set, mocked_responses, vinyldns_client):
     check_record_set_changes_are_equal(change, r)
     mocked_responses.reset()
 
-def test_update_record_set_bad_dates(record_set, mocked_responses, vinyldns_client):
-    rs = copy.deepcopy(record_set)
+def test_update_record_set_bad_dates(txt_record_set, mocked_responses, vinyldns_client):
+    rs = copy.deepcopy(txt_record_set)
     rs.id = rs.name + 'id'
     rs.created = parse_datetime("2019-06-25T16:37:09+00:00")
     rs.updated = parse_datetime("2019-06-25T16:37:09+00:00")
+    rs.status = "Active"
+    rs.fqdn = "testfqdn"
+
     change = gen_rs_change(rs)
+
     mocked_responses.add(
         responses.PUT, f'http://test.com/zones/{rs.zone_id}/recordsets/{rs.id}',
-        body=to_json_string(change), status=400
+        body=to_json_string(change), status=200
     )
     r = vinyldns_client.update_record_set(rs)
-    # data = r.body
-    # print(data.status_code)
-    # assert data.status_code == 400
+
+    payload = json.loads(
+        mocked_responses.calls[-1].request.body
+    )
+
+    assert payload['zoneId'] == rs.zone_id
+    assert payload['id'] == rs.id
+    assert payload['name'] == rs.name
+    assert payload['type'] == rs.type
+    assert payload['ttl'] == rs.ttl
+    assert payload['records']
+
+    assert 'created' not in payload
+    assert 'updated' not in payload
+    assert 'status' not in payload
+    assert 'fqdn' not in payload
+
     check_record_set_changes_are_equal(change, r)
     mocked_responses.reset()
-
-
+    # # assert not hasattr(r, "created")
+    # assert not hasattr(r, "updated")
+    # # assert not hasattr(r, "status")
+    # assert not hasattr(r, "fqdn")
 
 
 def test_delete_record_set(record_set, mocked_responses, vinyldns_client):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -74,6 +74,7 @@ def test_update_record_set(record_set, mocked_responses, vinyldns_client):
     check_record_set_changes_are_equal(change, r)
     mocked_responses.reset()
 
+
 def test_update_record_set_bad_dates(txt_record_set, mocked_responses, vinyldns_client):
     rs = copy.deepcopy(txt_record_set)
     rs.id = rs.name + 'id'

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -21,6 +21,8 @@ from vinyldns.record import RecordSet, RecordSetChange, ListRecordSetsResponse, 
 from vinyldns.serdes import to_json_string, from_json_string
 from vinyldns.serdes import parse_datetime
 
+from vinyldns.record import RecordSetStatus
+
 
 def check_record_sets_are_equal(a, b):
     if a is None:

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -20,7 +20,6 @@ from sampledata import record_sets, record_set_values, gen_rs_change, forward_zo
 from vinyldns.record import RecordSet, RecordSetChange, ListRecordSetsResponse, ListRecordSetChangesResponse
 from vinyldns.serdes import to_json_string, from_json_string
 from vinyldns.serdes import parse_datetime
-
 from vinyldns.record import RecordSetStatus
 
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -19,6 +19,8 @@ from sampledata import record_sets, record_set_values, gen_rs_change, forward_zo
 from vinyldns.record import RecordSet, RecordSetChange, ListRecordSetsResponse, ListRecordSetChangesResponse
 from vinyldns.serdes import to_json_string, from_json_string
 
+from vinyldns.serdes import parse_datetime
+
 
 def check_record_sets_are_equal(a, b):
     if a is None:
@@ -72,6 +74,25 @@ def test_update_record_set(record_set, mocked_responses, vinyldns_client):
     check_record_set_changes_are_equal(change, r)
     mocked_responses.reset()
 
+def test_update_record_set_bad_dates(record_set, mocked_responses, vinyldns_client):
+    rs = copy.deepcopy(record_set)
+    rs.id = rs.name + 'id'
+    rs.created = parse_datetime("2019-06-25T16:37:09+00:00")
+    rs.updated = parse_datetime("2019-06-25T16:37:09+00:00")
+    change = gen_rs_change(rs)
+    mocked_responses.add(
+        responses.PUT, f'http://test.com/zones/{rs.zone_id}/recordsets/{rs.id}',
+        body=to_json_string(change), status=400
+    )
+    r = vinyldns_client.update_record_set(rs)
+    # data = r.body
+    # print(data.status_code)
+    # assert data.status_code == 400
+    check_record_set_changes_are_equal(change, r)
+    mocked_responses.reset()
+
+
+
 
 def test_delete_record_set(record_set, mocked_responses, vinyldns_client):
     rs = copy.deepcopy(record_set)
@@ -95,6 +116,7 @@ def test_get_record_set(record_set, mocked_responses, vinyldns_client):
         body=to_json_string(response), status=200
     )
     r = vinyldns_client.get_record_set(rs.zone_id, rs.id)
+
     check_record_sets_are_equal(rs, r)
     mocked_responses.reset()
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -80,8 +80,8 @@ def test_update_record_set_bad_dates(txt_record_set, mocked_responses, vinyldns_
     rs.id = rs.name + 'id'
     rs.created = parse_datetime("2019-06-25T16:37:09+00:00")
     rs.updated = parse_datetime("2019-06-25T16:37:09+00:00")
-    rs.status = "Active"
-    rs.fqdn = "testfqdn"
+    rs.status = RecordSetStatus.Active
+    rs.fqdn = f'{rs.name}.bar.'
 
     change = gen_rs_change(rs)
 
@@ -109,10 +109,6 @@ def test_update_record_set_bad_dates(txt_record_set, mocked_responses, vinyldns_
 
     check_record_set_changes_are_equal(change, r)
     mocked_responses.reset()
-    # # assert not hasattr(r, "created")
-    # assert not hasattr(r, "updated")
-    # # assert not hasattr(r, "status")
-    # assert not hasattr(r, "fqdn")
 
 
 def test_delete_record_set(record_set, mocked_responses, vinyldns_client):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -16,7 +16,8 @@ import copy
 import json
 import responses
 from sampledata import record_sets, record_set_values, gen_rs_change, forward_zone
-from vinyldns.record import RecordSet, RecordSetChange, ListRecordSetsResponse, ListRecordSetChangesResponse, RecordSetStatus
+from vinyldns.record import RecordSet, RecordSetChange, ListRecordSetsResponse
+from vinyldns.record import ListRecordSetChangesResponse, RecordSetStatus
 from vinyldns.serdes import to_json_string, from_json_string, parse_datetime
 
 


### PR DESCRIPTION
Problem: Issues with the created/updated datetime fields not being accepted in the update_record_set call.

Approach: Adjusting the update_record_set function to call a helper which creates a new payload leaving out any unnecessary fields that the API does not require (created, fqdn, updated, status etc). This way we will not receive any datetime parsing errors since the fields are not included. Only did this at the update record set level so it does not affect other API calls.

Validation: Created unit test that passes in bad fields to the payload and double checks that the field doesnt exist in the body when checked. Will assert an error if it does.

Closes #52