### PR TITLE
updated to release script: -add preflight checks for working directory , python installed, packages, gpg key locally exists

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -53,35 +53,50 @@ KEY_ID=
 VERSION_SEGMENT="patch"
 RELEASE_REMOTE=
 
-while [ "$1" != "" ]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         -p | --production )
             RELEASE_URL=""
             ;;
         -k | --key-id )
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --key-id requires a value" >&2
+                usage
+                exit 1
+            fi
             KEY_ID="$2"
-            shift
+            shift 2
             ;;
         -b | --bump )
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --bump requires a value" >&2
+                usage
+                exit 1
+            fi
             VERSION_SEGMENT="$2"
-            shift
+            shift 2
             ;;
         -r | --remote )
+            if [ $# -lt 2 ]; then
+                echo "ERROR: --remote requires a value" >&2
+                usage
+                exit 1
+            fi
             RELEASE_REMOTE="$2"
-            shift
+            shift 2
             ;;
         --)              # End of all options.
             shift
             break
             ;;
         -?*)
-            printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
-            shift
+            echo "ERROR: Unknown option: $1" >&2
+            usage
+            exit 1
             ;;
         *)               # Default case: If no more options then break out of the loop.
             break
     esac
-    shift
 done
 
 if [ -z "$KEY_ID" ]; then
@@ -110,6 +125,7 @@ echo "Checking required commands..."
 check_command git
 check_command python3
 check_command gpg
+check_command bumpversion
 
 # Check Python version (requires 3.11+ per setup.py)
 echo "Checking Python version..."
@@ -130,7 +146,6 @@ echo "✓ Python $PYTHON_VERSION"
 echo "Checking required Python packages..."
 check_python_module setuptools
 check_python_module wheel
-check_command bumpversion
 check_python_module twine
 check_python_module build
 echo "✓ All required Python packages are installed"
@@ -224,11 +239,9 @@ echo "✓ Upload completed successfully"
 if [ -z "${RELEASE_URL}" ]; then
     echo "Pushing Git commit and tags to remote..."
     
-    # Get current branch name
-    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    
-    # Push the commit
-    git push "$RELEASE_REMOTE" "${CURRENT_BRANCH}"
+    # Get current branch name and release tag
+    CURRENT_BRANCH=$(git symbolic-ref --short HEAD)
+    RELEASE_TAG=$(git describe --exact-match --tags HEAD)
 
     # Push the tags
     git push --atomic "$RELEASE_REMOTE" \

--- a/release.sh
+++ b/release.sh
@@ -12,6 +12,7 @@ function usage {
     printf "\t-b, --bump: which segment to bump: major | minor | patch\n"
     printf "\t-p, --production: use real pypi instead of test pypi (test is default)\n"
     printf "\t-k, --key-id: the key id to use to sign the artifacts\n"
+    printf "\t-r, --remote: the git remote name to push to (required for production)\n"
 }
 
 function check_command {
@@ -50,6 +51,7 @@ function check_gpg_key {
 RELEASE_URL="--repository-url https://test.pypi.org/legacy/"
 KEY_ID=
 VERSION_SEGMENT="patch"
+RELEASE_REMOTE=
 
 while [ "$1" != "" ]; do
     case "$1" in
@@ -62,6 +64,10 @@ while [ "$1" != "" ]; do
             ;;
         -b | --bump )
             VERSION_SEGMENT="$2"
+            shift
+            ;;
+        -r | --remote )
+            RELEASE_REMOTE="$2"
             shift
             ;;
         --)              # End of all options.
@@ -80,6 +86,13 @@ done
 
 if [ -z "$KEY_ID" ]; then
     echo "ERROR: You must specify a GPG KEY ID to use for signing artifacts" >&2
+    usage
+    exit 1
+fi
+
+# Check that remote is specified for production releases
+if [ -z "${RELEASE_URL}" ] && [ -z "$RELEASE_REMOTE" ]; then
+    echo "ERROR: You must specify a remote name with --remote for production releases" >&2
     usage
     exit 1
 fi
@@ -117,8 +130,9 @@ echo "✓ Python $PYTHON_VERSION"
 echo "Checking required Python packages..."
 check_python_module setuptools
 check_python_module wheel
-check_python_module bumpversion
+check_command bumpversion
 check_python_module twine
+check_python_module build
 echo "✓ All required Python packages are installed"
 
 # Check that Git working directory is clean
@@ -130,6 +144,18 @@ echo "✓ Git working directory is clean"
 echo "Checking GPG key..."
 check_gpg_key "$KEY_ID"
 echo "✓ GPG key '$KEY_ID' found"
+
+# Check that remote exists (only for production releases)
+if [ -n "$RELEASE_REMOTE" ]; then
+    echo "Checking Git remote '$RELEASE_REMOTE'..."
+    if ! git remote get-url "$RELEASE_REMOTE" &> /dev/null; then
+        echo "ERROR: Git remote '$RELEASE_REMOTE' does not exist" >&2
+        echo "Available remotes:" >&2
+        git remote -v >&2
+        exit 1
+    fi
+    echo "✓ Git remote '$RELEASE_REMOTE' exists"
+fi
 
 echo "=== Preflight checks passed ==="
 echo ""
@@ -202,10 +228,12 @@ if [ -z "${RELEASE_URL}" ]; then
     CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     
     # Push the commit
-    git push origin "${CURRENT_BRANCH}"
-    
+    git push "$RELEASE_REMOTE" "${CURRENT_BRANCH}"
+
     # Push the tags
-    git push origin --tags
+    git push --atomic "$RELEASE_REMOTE" \
+          "HEAD:refs/heads/${CURRENT_BRANCH}" \
+          "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
     
     echo "✓ Git commit and tags pushed successfully"
 else

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Enable strict error handling before anything else
+set -euo pipefail
+
 DIR=$( cd $(dirname $0) ; pwd -P )
 
 function usage {
@@ -11,8 +14,40 @@ function usage {
     printf "\t-k, --key-id: the key id to use to sign the artifacts\n"
 }
 
+function check_command {
+    if ! command -v "$1" &> /dev/null; then
+        echo "ERROR: Required command '$1' is not available" >&2
+        exit 1
+    fi
+}
+
+function check_python_module {
+    if ! python3 -c "import $1" &> /dev/null; then
+        echo "ERROR: Required Python module '$1' is not installed" >&2
+        echo "Install it with: pip install $1" >&2
+        exit 1
+    fi
+}
+
+function check_git_clean {
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "ERROR: Working directory is not clean. Commit or stash changes before releasing." >&2
+        git status --short >&2
+        exit 1
+    fi
+}
+
+function check_gpg_key {
+    local key_id="$1"
+    if ! gpg --list-secret-keys "$key_id" &> /dev/null; then
+        echo "ERROR: GPG key '$key_id' not found in local keyring" >&2
+        echo "Available keys:" >&2
+        gpg --list-secret-keys --keyid-format LONG >&2
+        exit 1
+    fi
+}
+
 RELEASE_URL="--repository-url https://test.pypi.org/legacy/"
-KEY_ID=
 KEY_ID=
 VERSION_SEGMENT="patch"
 
@@ -44,54 +79,139 @@ while [ "$1" != "" ]; do
 done
 
 if [ -z "$KEY_ID" ]; then
-    echo "You must specify a GPG KEY ID on your system to use to sign the artifacts"
+    echo "ERROR: You must specify a GPG KEY ID to use for signing artifacts" >&2
     usage
     exit 1
 fi
 
-echo "Clearing the dist directory..."
-rm -rf ${DIR}/dist
+# Validate version segment
+if [[ ! "$VERSION_SEGMENT" =~ ^(major|minor|patch)$ ]]; then
+    echo "ERROR: Invalid version segment '$VERSION_SEGMENT'. Must be major, minor, or patch." >&2
+    exit 1
+fi
 
+echo "=== Running preflight checks ==="
+
+# Check that required commands are available
+echo "Checking required commands..."
+check_command git
+check_command python3
+check_command gpg
+
+# Check Python version (requires 3.11+ per setup.py)
+echo "Checking Python version..."
+PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+REQUIRED_MAJOR=3
+REQUIRED_MINOR=11
+CURRENT_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+CURRENT_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+
+if [ "$CURRENT_MAJOR" -lt "$REQUIRED_MAJOR" ] || \
+   ([ "$CURRENT_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$CURRENT_MINOR" -lt "$REQUIRED_MINOR" ]); then
+    echo "ERROR: Python $REQUIRED_MAJOR.$REQUIRED_MINOR+ required, but found $PYTHON_VERSION" >&2
+    exit 1
+fi
+echo "✓ Python $PYTHON_VERSION"
+
+# Check that required Python modules are installed
+echo "Checking required Python packages..."
+check_python_module setuptools
+check_python_module wheel
+check_python_module bumpversion
+check_python_module twine
+echo "✓ All required Python packages are installed"
+
+# Check that Git working directory is clean
+echo "Checking Git working directory..."
+check_git_clean
+echo "✓ Git working directory is clean"
+
+# Check that GPG key exists
+echo "Checking GPG key..."
+check_gpg_key "$KEY_ID"
+echo "✓ GPG key '$KEY_ID' found"
+
+echo "=== Preflight checks passed ==="
+echo ""
+
+# Clear the dist directory
+echo "Clearing the dist directory..."
+rm -rf "${DIR}/dist"
+
+# Bump version
 if [ "${VERSION_SEGMENT}" == "major" ]; then
     echo "Bumping the major version..."
 elif [ "${VERSION_SEGMENT}" == "minor" ]; then
     echo "Bumping the minor version..."
 else
     echo "Bumping the patch version..."
-    VERSION_SEGMENT="patch" # ensure we are setting patch here
 fi
 
 if [ -z "${RELEASE_URL}" ]; then
+    echo "Creating version commit and tag (production mode)..."
     bumpversion "${VERSION_SEGMENT}"
 else
+    echo "Bumping version without commit/tag (test mode)..."
     bumpversion "${VERSION_SEGMENT}" --no-tag --no-commit
 fi
 
-bump_result=$?
+echo "✓ Version bumped successfully"
 
-if [ "${bump_result}" != 0 ]; then
-    echo "Bumping version failed ${bump_result}!"
+# Build artifacts
+echo "Building the artifacts..."
+python3 -m build --sdist --wheel --outdir "${DIR}/dist"
+echo "✓ Artifacts built successfully"
+
+# Verify dist directory exists and has content
+if [ ! -d "${DIR}/dist" ] || [ -z "$(ls -A "${DIR}/dist")" ]; then
+    echo "ERROR: dist directory is missing or empty after build" >&2
     exit 1
 fi
 
-echo "Building the artifacts..."
-python3 setup.py sdist bdist_wheel
+# Check artifacts with twine
+echo "Validating artifacts with twine check..."
+python3 -m twine check "${DIR}/dist/"*
+echo "✓ Artifacts validated successfully"
 
-echo "Signing using GPG with key ${KEY_ID} get your passphrase ready..."
-cd ${DIR}/dist
-for file in $(ls);
-do
-    echo "gpg -a -u ${KEY_ID} --detach-sign $file"
-    gpg -a -u ${KEY_ID} --detach-sign $file
+# Sign artifacts
+echo "Signing artifacts using GPG with key ${KEY_ID}..."
+echo "Get your passphrase ready..."
+cd "${DIR}/dist"
+
+for file in *; do
+    # Only sign regular files (not directories or links)
+    if [ -f "$file" ] && [ ! -L "$file" ]; then
+        echo "Signing: $file"
+        gpg -a -u "${KEY_ID}" --detach-sign "$file"
+    fi
 done
 
-echo "Uploading to pypi at ${RELEASE_URL}..."
-twine upload ${RELEASE_URL} ${DIR}/dist/*
+echo "✓ Artifacts signed successfully"
 
+# Upload to PyPI
+echo "Uploading to PyPI ${RELEASE_URL:-(production)}..."
+cd "${DIR}"
+python3 -m twine upload ${RELEASE_URL} "${DIR}/dist/"*
+echo "✓ Upload completed successfully"
+
+# Push Git changes (only in production mode)
 if [ -z "${RELEASE_URL}" ]; then
-    echo "Pushing git tags..."
-    git push
-    git push --tags
+    echo "Pushing Git commit and tags to remote..."
+    
+    # Get current branch name
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    
+    # Push the commit
+    git push origin "${CURRENT_BRANCH}"
+    
+    # Push the tags
+    git push origin --tags
+    
+    echo "✓ Git commit and tags pushed successfully"
 else
-    echo "Skipping push to git!"
+    echo "⚠ Skipping Git push (test mode)"
+    echo "Note: Version was bumped locally but not committed to Git"
 fi
+
+echo ""
+echo "=== Release completed successfully ==="

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -52,7 +52,10 @@ if [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
     fi
 else
     if [[ "$1" == "-m" ]] && [[ "$2" == "build" ]]; then
-    echo "SUCCESS: Build succeeded" >&2
+        mkdir -p dist
+        touch dist/vinyldns-python-0.9.11-py3-none-any.whl
+        touch dist/vinyldns-python-0.9.11.tar.gz
+        echo "SUCCESS: Build succeeded" >&2
         exit 0
     fi
 fi
@@ -65,7 +68,7 @@ if [[ "$RELEASE_TEST_FAIL" == "twine-check" ]]; then
     fi
 elif [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
     if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]]; then
-        echo "ERROR: Twine check should not happen after failed build >&2
+        echo "ERROR: Twine check should not happen after failed build" >&2
         exit 1
     fi
 else
@@ -82,7 +85,7 @@ exit 1
     fake_python.chmod(0o755)
 
 
-def create_fake_git(bin_dir: Path, log_file: Path, release_test_fail) -> None:
+def create_fake_git(bin_dir: Path, log_file: Path,test_dir: Path, release_test_fail) -> None:
     """Create a fake git executable that handles status, remote, and push commands."""
 
     fake_git = bin_dir / "git"
@@ -140,13 +143,14 @@ exit 1
     fake_git.chmod(0o755)
 
 
-def create_fake_gpg(bin_dir: Path, log_file: Path) -> None:
+def create_fake_gpg(bin_dir: Path, log_file: Path, release_test_fail) -> None:
     """Create a fake gpg executable that handles key checks and signing."""
 
     fake_gpg = bin_dir / "gpg"
     fake_gpg.write_text(f'''#!/usr/bin/env bash
 
 LOG_FILE="{log_file}"
+RELEASE_TEST_FAIL={release_test_fail}
 
 # Log all invocations
 echo "gpg $@" >> "$LOG_FILE"
@@ -158,12 +162,25 @@ if [[ "$1" == "--list-secret-keys" ]]; then
 fi
 
 # Handle signing with --detach-sign
-if [[ "$2" == "-u" ]] && [[ "$4" == "--detach-sign" ]]; then
-    # Forbidden operation - fail immediately
-    echo "ERROR: gpg --detach-sign should not be called in this test (build failed)" >&2
-    exit 1
+if [[ "$RELEASE_TEST_FAIL" == "twine-check" ]] || [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
+    if [[ "$2" == "-u" ]] && [[ "$4" == "--detach-sign" ]]; then
+        # Forbidden operation - fail immediately
+        echo "ERROR: gpg --detach-sign should not be called in this test (build/twine-check failed)" >&2
+        exit 1
+    fi
+elif [[ "$RELEASE_TEST_FAIL" == "gpg-sign" ]]; then
+    if [[ "$2" == "-u" ]] && [[ "$4" == "--detach-sign" ]]; then
+        # Force fail
+        echo "ERROR: gpg --detach-sign error" >&2
+        exit 1
+    fi
+else 
+    if [[ "$2" == "-u" ]] && [[ "$4" == "--detach-sign" ]]; then
+            # Success - sign the file
+            echo "SUCCESS: gpg --detach-sign" >&2
+            exit 0
+    fi
 fi
-
 # Default: unknown invocation
 echo "ERROR: Unknown gpg invocation: $@" >&2
 exit 1
@@ -189,7 +206,7 @@ exit 0
     fake_bumpversion.chmod(0o755)
 
 
-def test_failed_build_does_not_sign_upload_or_push(tmp_path):
+def run_release(tmp_path, fail_at):
     """Test that when python3 -m build fails, the script does not sign, upload, or push."""
 
     # Setup test directory structure
@@ -205,9 +222,9 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
     log_file.touch()
 
     # Create fake executables
-    create_fake_python3(bin_dir, log_file, 'build')
-    create_fake_git(bin_dir, log_file, test_dir)
-    create_fake_gpg(bin_dir, log_file)
+    create_fake_python3(bin_dir, log_file, fail_at)
+    create_fake_git(bin_dir, log_file, test_dir, fail_at)
+    create_fake_gpg(bin_dir, log_file, fail_at)
     create_fake_bumpversion(bin_dir, log_file, test_dir)
 
     # Copy release.sh to test directory
@@ -243,15 +260,20 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
         text=True
     )
 
-    # Read the command log
-    command_log = log_file.read_text()
-
     print("=== release.sh stdout ===")
     print(result.stdout)
     print("=== release.sh stderr ===")
     print(result.stderr)
     print("=== stub command log ===")
     print(log_file.read_text())
+
+    return result, log_file.read_text()
+
+
+def test_failed_build_stops_release(tmp_path):
+    """Test that when python3 -m build fails, the script stops and does not proceed."""
+    fail_at = 'build'
+    result, command_log = run_release(tmp_path, fail_at)
 
     # Assertions:
 
@@ -288,3 +310,98 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
         f"Expected no success message, but stdout contains:\n{result.stdout}"
     assert "Release completed successfully" not in result.stderr, \
         f"Expected no success message, but stderr contains:\n{result.stderr}"
+
+
+def test_failed_twine_check_stops_release(tmp_path):
+    """Test that when python3 -m build fails, the script stops and does not proceed."""
+    fail_at = 'twine-check'
+    result, command_log = run_release(tmp_path, fail_at)
+
+    # Assertions:
+
+    # 1. Script should return nonzero exit code (twine-check failed)
+    assert result.returncode != 0, \
+        f"Expected nonzero exit code, got {result.returncode}"
+
+    # 2. Twine check was attempted
+    assert "python3 -m twine check" in command_log, \
+        f"Expected 'python3 -m twine check' in log, but found:\n{command_log}"
+
+    # 3. No GPG signing invocation (--detach-sign)
+    # Note: --list-secret-keys is expected for preflight check
+    gpg_sign_commands = [line for line in command_log.split('\n')
+                         if 'gpg' in line and '--detach-sign' in line]
+    assert len(gpg_sign_commands) == 0, \
+        f"Expected no GPG signing, but found:\n{chr(10).join(gpg_sign_commands)}"
+
+    # 4. No git push invocation
+    # Note: git status and other preflight calls are expected
+    git_push_commands = [line for line in command_log.split('\n')
+                         if 'git push' in line]
+    assert len(git_push_commands) == 0, \
+        f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"
+
+    # 5. Script does not print successful-completion message
+    assert "Release completed successfully" not in result.stdout, \
+        f"Expected no success message, but stdout contains:\n{result.stdout}"
+    assert "Release completed successfully" not in result.stderr, \
+        f"Expected no success message, but stderr contains:\n{result.stderr}"
+
+def test_failed_gpg_sign_stops_release(tmp_path):
+    """Test that when python3 -m build fails, the script stops and does not proceed."""
+    fail_at = 'gpg-sign'
+    result, command_log = run_release(tmp_path, fail_at)
+
+    # Assertions:
+
+    # 1. Script should return nonzero exit code (twine-check failed)
+    assert result.returncode != 0, \
+        f"Expected nonzero exit code, got {result.returncode}"
+
+    # 2. GPG signing was attempted
+    assert [line for line in command_log.split('\n')
+            if 'gpg' in line and '--detach-sign' in line], \
+        f"Expected 'gpg and --detach-sign' in log, but found:\n{command_log}"
+
+    # 3. No git push invocation
+    # Note: git status and other preflight calls are expected
+    git_push_commands = [line for line in command_log.split('\n')
+                         if 'git push' in line]
+    assert len(git_push_commands) == 0, \
+        f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"
+
+    # 4. Script does not print successful-completion message
+    assert "Release completed successfully" not in result.stdout, \
+        f"Expected no success message, but stdout contains:\n{result.stdout}"
+    assert "Release completed successfully" not in result.stderr, \
+        f"Expected no success message, but stderr contains:\n{result.stderr}"
+
+# def test_failed_twine_upload_stops_release(tmp_path):
+#     """Test that when python3 -m build fails, the script stops and does not proceed."""
+#     fail_at = 'twine-upload'
+#     result, command_log = run_release(tmp_path, fail_at)
+#
+#     # Assertions:
+#
+#     # 1. Script should return nonzero exit code (twine-check failed)
+#     assert result.returncode != 0, \
+#         f"Expected nonzero exit code, got {result.returncode}"
+#
+#     # 2. Twine upload was attempted
+#     assert "python3 -m twine upload" in command_log, \
+#         f"Expected 'python3 -m twine upload' in log, but found:\n{command_log}"
+#
+#     # 3. No git push invocation
+#     # Note: git status and other preflight calls are expected
+#     git_push_commands = [line for line in command_log.split('\n')
+#                          if 'git push' in line]
+#     assert len(git_push_commands) == 0, \
+#         f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"
+#
+#     # 4. Script does not print successful-completion message
+#     assert "Release completed successfully" not in result.stdout, \
+#         f"Expected no success message, but stdout contains:\n{result.stdout}"
+#     assert "Release completed successfully" not in result.stderr, \
+#         f"Expected no success message, but stderr contains:\n{result.stderr}"
+
+

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -43,7 +43,7 @@ if [[ "$1" == "-c" ]] && [[ "$2" == *"import "* ]]; then
     exit 0
 fi
 
-# Handle -m build 
+# Handle -m build
 
 if [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
     if [[ "$1" == "-m" ]] && [[ "$2" == "build" ]]; then
@@ -57,7 +57,7 @@ else
     fi
 fi
 
-# Handle -m twine 
+# Handle -m twine
 if [[ "$RELEASE_TEST_FAIL" == "twine-check" ]]; then
     if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]]; then
         echo "ERROR: twine check error" >&2
@@ -205,7 +205,7 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
     log_file.touch()
 
     # Create fake executables
-    create_fake_python3(bin_dir, log_file,'build')
+    create_fake_python3(bin_dir, log_file, 'build')
     create_fake_git(bin_dir, log_file, test_dir)
     create_fake_gpg(bin_dir, log_file)
     create_fake_bumpversion(bin_dir, log_file, test_dir)

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,255 @@
+# Copyright 2018 Comcast Cable Communications Management, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+def create_fake_python3(bin_dir: Path, log_file: Path) -> None:
+    """Create a fake python3 executable that handles version probes, import checks,
+    and records -m build and -m twine invocations."""
+    
+    fake_python = bin_dir / "python3"
+    fake_python.write_text(f'''#!/usr/bin/env bash
+set -e
+
+LOG_FILE="{log_file}"
+
+# Log all invocations
+echo "python3 $*" >> "$LOG_FILE"
+
+# Handle version check
+if [[ "$*" == *"sys.version_info"* ]]; then
+    echo "3.11"
+    exit 0
+fi
+
+# Handle import checks
+if [[ "$*" == "-c "* ]] && [[ "$*" == *"import "* ]]; then
+    # Extract module name - handle cases like "import setuptools"
+    exit 0
+fi
+
+# Handle -m build - return failure for this test
+if [[ "$*" == "-m build"* ]]; then
+    echo "ERROR: Build failed" >&2
+    exit 1
+fi
+
+# Handle -m twine - should not be called in this test
+if [[ "$*" == "-m twine"* ]]; then
+    echo "ERROR: twine should not be called after build failure" >&2
+    exit 1
+fi
+
+# Default: unknown invocation
+echo "ERROR: Unknown python3 invocation: $*" >&2
+exit 1
+''', encoding='utf-8')
+    fake_python.chmod(0o755)
+
+def create_fake_git(bin_dir: Path, log_file: Path, test_dir: Path) -> None:
+    """Create a fake git executable that handles status, remote, and push commands."""
+    
+    fake_git = bin_dir / "git"
+    fake_git.write_text(f'''#!/usr/bin/env bash
+set -e
+
+LOG_FILE="{log_file}"
+
+# Log all invocations
+echo "git $*" >> "$LOG_FILE"
+
+case "$1" in
+    status)
+        if [[ "$2" == "--porcelain" ]]; then
+            # Return empty output (clean working directory)
+            exit 0
+        elif [[ "$2" == "--short" ]]; then
+            exit 0
+        fi
+        ;;
+    remote)
+        if [[ "$2" == "get-url" ]]; then
+            # Pretend the remote exists
+            echo "https://github.com/vinyldns/vinyldns-python.git"
+            exit 0
+        elif [[ "$2" == "-v" ]]; then
+            echo "origin\thttps://github.com/vinyldns/vinyldns-python.git (fetch)"
+            echo "origin\thttps://github.com/vinyldns/vinyldns-python.git (push)"
+            exit 0
+        fi
+        ;;
+    symbolic-ref)
+        if [[ "$2" == "--short" ]] && [[ "$3" == "HEAD" ]]; then
+            echo "main"
+            exit 0
+        fi
+        ;;
+    describe)
+        if [[ "$*" == *"--exact-match"* ]] && [[ "$*" == *"--tags"* ]]; then
+            echo "v0.9.11"
+            exit 0
+        fi
+        ;;
+    push)
+        # This should NOT be called in this test
+        exit 0
+        ;;
+esac
+
+exit 0
+''', encoding='utf-8')
+    fake_git.chmod(0o755)
+
+def create_fake_gpg(bin_dir: Path, log_file: Path) -> None:
+    """Create a fake gpg executable that handles key checks and signing."""
+    
+    fake_gpg = bin_dir / "gpg"
+    fake_gpg.write_text(f'''#!/usr/bin/env bash
+set -e
+
+LOG_FILE="{log_file}"
+
+# Log all invocations
+echo "gpg $*" >> "$LOG_FILE"
+
+# Handle --list-secret-keys (preflight check)
+if [[ "$*" == *"--list-secret-keys"* ]]; then
+    # Just succeed - key exists
+    exit 0
+fi
+
+# Handle signing with --detach-sign
+if [[ "$*" == *"--detach-sign"* ]]; then
+    # This should NOT be called in this test (build failed)
+    exit 0
+fi
+
+exit 0
+''', encoding='utf-8')
+    fake_gpg.chmod(0o755)
+
+def create_fake_bumpversion(bin_dir: Path, log_file: Path, test_dir: Path) -> None:
+    """Create a fake bumpversion executable that simulates version bumping."""
+    
+    fake_bumpversion = bin_dir / "bumpversion"
+    fake_bumpversion.write_text(f'''#!/usr/bin/env bash
+set -e
+
+LOG_FILE="{log_file}"
+
+# Log all invocations
+echo "bumpversion $*" >> "$LOG_FILE"
+
+# Simulate successful version bump
+exit 0
+''', encoding='utf-8')
+    fake_bumpversion.chmod(0o755)
+
+def test_failed_build_does_not_sign_upload_or_push(tmp_path):
+    """Test that when python3 -m build fails, the script does not sign, upload, or push."""
+    # Setup test directory structure
+    test_dir = tmp_path / "test_release_script"
+    test_dir.mkdir()
+    
+    # Create bin directory for fake executables
+    bin_dir = test_dir / "bin"
+    bin_dir.mkdir()
+    
+    # Create shared log file
+    log_file = test_dir / "command.log"
+    log_file.touch()
+    
+    # Create fake executables
+    create_fake_python3(bin_dir, log_file)
+    create_fake_git(bin_dir, log_file, test_dir)
+    create_fake_gpg(bin_dir, log_file)
+    create_fake_bumpversion(bin_dir, log_file, test_dir)
+    
+    # Copy release.sh to test directory
+    project_root = Path(__file__).parent.parent
+    release_script = project_root / "release.sh"
+    test_release_script = test_dir / "release.sh"
+    shutil.copy(release_script, test_release_script)
+    test_release_script.chmod(0o755)
+    
+    # Copy required files for the script
+    for file_name in ["setup.py", "setup.cfg", "README.md"]:
+        src_file = project_root / file_name
+        if src_file.exists():
+            shutil.copy(src_file, test_dir / file_name)
+    
+    # Copy src directory structure (required for build)
+    src_dir = project_root / "src"
+    if src_dir.exists():
+        shutil.copytree(src_dir, test_dir / "src")
+    
+    # Prepare environment
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["RELEASE_TEST_LOG"] = str(log_file)
+    
+    # Run release.sh with arguments that trigger production path
+    # Using test mode (no --production) to avoid git push requirement during preflight
+    result = subprocess.run(
+        ["bash", str(test_release_script), "--key-id", "test-key-123"],
+        cwd=test_dir,
+        env=env,
+        capture_output=True,
+        text=True
+    )
+    
+    # Read the command log
+    command_log = log_file.read_text()
+    
+    # Assertions:
+    
+    # 1. Script should return nonzero exit code (build failed)
+    assert result.returncode != 0, \
+        f"Expected nonzero exit code, got {result.returncode}"
+    
+    # 2. Build was attempted
+    assert "python3 -m build" in command_log, \
+        f"Expected 'python3 -m build' in log, but found:\n{command_log}"
+    
+    # 3. No GPG signing invocation (--detach-sign)
+    # Note: --list-secret-keys is expected for preflight check
+    gpg_sign_commands = [line for line in command_log.split('\n') 
+                         if 'gpg' in line and '--detach-sign' in line]
+    assert len(gpg_sign_commands) == 0, \
+        f"Expected no GPG signing, but found:\n{chr(10).join(gpg_sign_commands)}"
+    
+    # 4. No twine check or upload invocation
+    twine_commands = [line for line in command_log.split('\n') 
+                      if 'python3 -m twine' in line]
+    assert len(twine_commands) == 0, \
+        f"Expected no twine invocations, but found:\n{chr(10).join(twine_commands)}"
+    
+    # 5. No git push invocation
+    # Note: git status and other preflight calls are expected
+    git_push_commands = [line for line in command_log.split('\n') 
+                         if 'git push' in line]
+    assert len(git_push_commands) == 0, \
+        f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"
+    
+    # 6. Script does not print successful-completion message
+    assert "Release completed successfully" not in result.stdout, \
+        f"Expected no success message, but stdout contains:\n{result.stdout}"
+    assert "Release completed successfully" not in result.stderr, \
+        f"Expected no success message, but stderr contains:\n{result.stderr}"
+    temp_directory = tmp_path / "test_release"
+    temp_directory.mkdir()
+

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -18,7 +18,7 @@ import subprocess
 from pathlib import Path
 
 
-def create_fake_python3(bin_dir: Path, log_file: Path) -> None:
+def create_fake_python3(bin_dir: Path, log_file: Path, release_test_fail) -> None:
     """Create a fake python3 executable that handles version probes, import checks,
     and records -m build and -m twine invocations."""
 
@@ -26,6 +26,7 @@ def create_fake_python3(bin_dir: Path, log_file: Path) -> None:
     fake_python.write_text(f'''#!/usr/bin/env bash
 set -e
 
+RELEASE_TEST_FAIL={release_test_fail}
 LOG_FILE="{log_file}"
 
 # Log all invocations
@@ -42,16 +43,36 @@ if [[ "$1" == "-c" ]] && [[ "$2" == *"import "* ]]; then
     exit 0
 fi
 
-# Handle -m build - return failure for this test
-if [[ "$1" == "-m" ]] && [[ "$2" == "build" ]]; then
-    echo "ERROR: Build failed" >&2
-    exit 1
+# Handle -m build 
+
+if [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
+    if [[ "$1" == "-m" ]] && [[ "$2" == "build" ]]; then
+        echo "ERROR: Build failed" >&2
+        exit 1
+    fi
+else
+    if [[ "$1" == "-m" ]] && [[ "$2" == "build" ]]; then
+    echo "SUCCESS: Build succeeded" >&2
+        exit 0
+    fi
 fi
 
-# Handle -m twine - should not be called in this test
-if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]]; then
-    echo "ERROR: twine should not be called after build failure" >&2
-    exit 1
+# Handle -m twine 
+if [[ "$RELEASE_TEST_FAIL" == "twine-check" ]]; then
+    if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]]; then
+        echo "ERROR: twine check error" >&2
+        exit 1
+    fi
+elif [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
+    if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]]; then
+        echo "ERROR: Twine check should not happen after failed build >&2
+        exit 1
+    fi
+else
+    if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]]; then
+        echo "SUCCESS: Twine check passed" >&2
+        exit 0
+    fi
 fi
 
 # Default: unknown invocation
@@ -223,6 +244,13 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
 
     # Read the command log
     command_log = log_file.read_text()
+
+    print("=== release.sh stdout ===")
+    print(result.stdout)
+    print("=== release.sh stderr ===")
+    print(result.stderr)
+    print("=== stub command log ===")
+    print(log_file.read_text())
 
     # Assertions:
 

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -82,13 +82,14 @@ exit 1
     fake_python.chmod(0o755)
 
 
-def create_fake_git(bin_dir: Path, log_file: Path, test_dir: Path) -> None:
+def create_fake_git(bin_dir: Path, log_file: Path, release_test_fail) -> None:
     """Create a fake git executable that handles status, remote, and push commands."""
 
     fake_git = bin_dir / "git"
     fake_git.write_text(f'''#!/usr/bin/env bash
 
 LOG_FILE="{log_file}"
+RELEASE_TEST_FAIL={release_test_fail}
 
 # Log all invocations
 echo "git $@" >> "$LOG_FILE"
@@ -204,7 +205,7 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
     log_file.touch()
 
     # Create fake executables
-    create_fake_python3(bin_dir, log_file)
+    create_fake_python3(bin_dir, log_file,'build')
     create_fake_git(bin_dir, log_file, test_dir)
     create_fake_gpg(bin_dir, log_file)
     create_fake_bumpversion(bin_dir, log_file, test_dir)

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -170,44 +170,44 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
     # Setup test directory structure
     test_dir = tmp_path / "test_release_script"
     test_dir.mkdir()
-    
+
     # Create bin directory for fake executables
     bin_dir = test_dir / "bin"
     bin_dir.mkdir()
-    
+
     # Create shared log file
     log_file = test_dir / "command.log"
     log_file.touch()
-    
+
     # Create fake executables
     create_fake_python3(bin_dir, log_file)
     create_fake_git(bin_dir, log_file, test_dir)
     create_fake_gpg(bin_dir, log_file)
     create_fake_bumpversion(bin_dir, log_file, test_dir)
-    
+
     # Copy release.sh to test directory
     project_root = Path(__file__).parent.parent
     release_script = project_root / "release.sh"
     test_release_script = test_dir / "release.sh"
     shutil.copy(release_script, test_release_script)
     test_release_script.chmod(0o755)
-    
+
     # Copy required files for the script
     for file_name in ["setup.py", "setup.cfg", "README.md"]:
         src_file = project_root / file_name
         if src_file.exists():
             shutil.copy(src_file, test_dir / file_name)
-    
+
     # Copy src directory structure (required for build)
     src_dir = project_root / "src"
     if src_dir.exists():
         shutil.copytree(src_dir, test_dir / "src")
-    
+
     # Prepare environment
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
     env["RELEASE_TEST_LOG"] = str(log_file)
-    
+
     # Run release.sh with arguments that trigger production path
     # Using test mode (no --production) to avoid git push requirement during preflight
     result = subprocess.run(
@@ -218,23 +218,18 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
         text=True
     )
 
-
     # Read the command log
     command_log = log_file.read_text()
 
-
     # Assertions:
-
 
     # 1. Script should return nonzero exit code (build failed)
     assert result.returncode != 0, \
         f"Expected nonzero exit code, got {result.returncode}"
 
-
     # 2. Build was attempted
     assert "python3 -m build" in command_log, \
         f"Expected 'python3 -m build' in log, but found:\n{command_log}"
-
 
     # 3. No GPG signing invocation (--detach-sign)
     # Note: --list-secret-keys is expected for preflight check
@@ -243,13 +238,11 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
     assert len(gpg_sign_commands) == 0, \
         f"Expected no GPG signing, but found:\n{chr(10).join(gpg_sign_commands)}"
 
-
     # 4. No twine check or upload invocation
     twine_commands = [line for line in command_log.split('\n') 
                       if 'python3 -m twine' in line]
     assert len(twine_commands) == 0, \
         f"Expected no twine invocations, but found:\n{chr(10).join(twine_commands)}"
-
 
     # 5. No git push invocation
     # Note: git status and other preflight calls are expected
@@ -257,7 +250,6 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
                          if 'git push' in line]
     assert len(git_push_commands) == 0, \
         f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"
-
 
     # 6. Script does not print successful-completion message
     assert "Release completed successfully" not in result.stdout, \

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -33,13 +33,23 @@ LOG_FILE="{log_file}"
 echo "python3 $@" >> "$LOG_FILE"
 
 # Handle version check
-if [[ "$1" == "-c" ]] && [[ "$2" == *"sys.version_info"* ]]; then
+if [[ "$RELEASE_TEST_FAIL" == "python-version" ]]; then
+    if [[ "$1" == "-c" ]] && [[ "$2" == *"sys.version_info"* ]]; then
+        echo "2.7"  # Unsupported version
+        exit 0
+    fi
+elif [[ "$1" == "-c" ]] && [[ "$2" == *"sys.version_info"* ]]; then
     echo "3.11"
     exit 0
 fi
 
 # Handle import checks
-if [[ "$1" == "-c" ]] && [[ "$2" == *"import "* ]]; then
+if [[ "$RELEASE_TEST_FAIL" == "missing-dependencies" ]]; then
+    if [[ "$1" == "-c" ]] && [[ "$2" == *"import "* ]]; then
+        echo "ERROR: Missing dependency" >&2
+        exit 1
+    fi
+elif [[ "$1" == "-c" ]] && [[ "$2" == *"import "* ]]; then
     exit 0
 fi
 
@@ -62,8 +72,16 @@ fi
 
 # Handle -m twine
 if [[ "$RELEASE_TEST_FAIL" == "twine-check" ]]; then
-    if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]]; then
+    if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]] && [[ "$3" == "check" ]]; then
         echo "ERROR: twine check error" >&2
+        exit 1
+    fi
+elif [[ "$RELEASE_TEST_FAIL" == "twine-upload" ]]; then
+    if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]] && [[ "$3" == "check" ]]; then
+        echo "SUCCESS: Twine check passed" >&2
+        exit 0
+    elif [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]] && [[ "$3" == "upload" ]]; then
+        echo "ERROR: Twine upload failed" >&2
         exit 1
     fi
 elif [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
@@ -85,7 +103,7 @@ exit 1
     fake_python.chmod(0o755)
 
 
-def create_fake_git(bin_dir: Path, log_file: Path,test_dir: Path, release_test_fail) -> None:
+def create_fake_git(bin_dir: Path, log_file: Path, test_dir: Path, release_test_fail) -> None:
     """Create a fake git executable that handles status, remote, and push commands."""
 
     fake_git = bin_dir / "git"
@@ -100,8 +118,14 @@ echo "git $@" >> "$LOG_FILE"
 case "$1" in
     status)
         if [[ "$2" == "--porcelain" ]]; then
-            # Return empty output (clean working directory)
-            exit 0
+            if [[ "$RELEASE_TEST_FAIL" == "dirty-tree" ]]; then
+                # Return output indicating uncommitted changes
+                echo " M some-file.py"
+                exit 0
+            else
+                # Return empty output (clean working directory)
+                exit 0
+            fi
         elif [[ "$2" == "--short" ]]; then
             exit 0
         fi
@@ -130,9 +154,17 @@ case "$1" in
         fi
         ;;
     push)
-        # Forbidden operation - fail immediately
-        echo "ERROR: git push should not be called in this test" >&2
-        exit 1
+        if [[ "$RELEASE_TEST_FAIL" == "git-push" ]]; then
+            echo "ERROR: git push failed" >&2
+            exit 1
+        elif [[ "$RELEASE_TEST_FAIL" == "twine-upload" ]] || [[ "$RELEASE_TEST_FAIL" == "gpg-sign" ]] || \
+             [[ "$RELEASE_TEST_FAIL" == "twine-check" ]] || [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
+            # Forbidden operation - fail immediately
+            echo "ERROR: git push should not be called in this test" >&2
+            exit 1
+        else
+            exit 0
+        fi
         ;;
 esac
 
@@ -157,15 +189,22 @@ echo "gpg $@" >> "$LOG_FILE"
 
 # Handle --list-secret-keys (preflight check)
 if [[ "$1" == "--list-secret-keys" ]]; then
-    # Just succeed - key exists
-    exit 0
+    if [[ "$RELEASE_TEST_FAIL" == "missing-gpg-key" ]]; then
+        echo "ERROR: GPG key not found" >&2
+        exit 2
+    else
+        # Just succeed - key exists
+        exit 0
+    fi
 fi
 
 # Handle signing with --detach-sign
-if [[ "$RELEASE_TEST_FAIL" == "twine-check" ]] || [[ "$RELEASE_TEST_FAIL" == "build" ]]; then
+if [[ "$RELEASE_TEST_FAIL" == "twine-check" ]] || [[ "$RELEASE_TEST_FAIL" == "build" ]] || \
+   [[ "$RELEASE_TEST_FAIL" == "missing-dependencies" ]] || [[ "$RELEASE_TEST_FAIL" == "python-version" ]] || \
+   [[ "$RELEASE_TEST_FAIL" == "dirty-tree" ]] || [[ "$RELEASE_TEST_FAIL" == "missing-gpg-key" ]]; then
     if [[ "$2" == "-u" ]] && [[ "$4" == "--detach-sign" ]]; then
         # Forbidden operation - fail immediately
-        echo "ERROR: gpg --detach-sign should not be called in this test (build/twine-check failed)" >&2
+        echo "ERROR: gpg --detach-sign should not be called in this test (preflight failed)" >&2
         exit 1
     fi
 elif [[ "$RELEASE_TEST_FAIL" == "gpg-sign" ]]; then
@@ -174,7 +213,7 @@ elif [[ "$RELEASE_TEST_FAIL" == "gpg-sign" ]]; then
         echo "ERROR: gpg --detach-sign error" >&2
         exit 1
     fi
-else 
+else
     if [[ "$2" == "-u" ]] && [[ "$4" == "--detach-sign" ]]; then
             # Success - sign the file
             echo "SUCCESS: gpg --detach-sign" >&2
@@ -313,7 +352,7 @@ def test_failed_build_stops_release(tmp_path):
 
 
 def test_failed_twine_check_stops_release(tmp_path):
-    """Test that when python3 -m build fails, the script stops and does not proceed."""
+    """Test that when python3 -m twine check fails, the script stops and does not proceed."""
     fail_at = 'twine-check'
     result, command_log = run_release(tmp_path, fail_at)
 
@@ -347,8 +386,9 @@ def test_failed_twine_check_stops_release(tmp_path):
     assert "Release completed successfully" not in result.stderr, \
         f"Expected no success message, but stderr contains:\n{result.stderr}"
 
+
 def test_failed_gpg_sign_stops_release(tmp_path):
-    """Test that when python3 -m build fails, the script stops and does not proceed."""
+    """Test that when gpg sign fails, the script stops and does not proceed."""
     fail_at = 'gpg-sign'
     result, command_log = run_release(tmp_path, fail_at)
 
@@ -376,32 +416,150 @@ def test_failed_gpg_sign_stops_release(tmp_path):
     assert "Release completed successfully" not in result.stderr, \
         f"Expected no success message, but stderr contains:\n{result.stderr}"
 
-# def test_failed_twine_upload_stops_release(tmp_path):
-#     """Test that when python3 -m build fails, the script stops and does not proceed."""
-#     fail_at = 'twine-upload'
-#     result, command_log = run_release(tmp_path, fail_at)
-#
-#     # Assertions:
-#
-#     # 1. Script should return nonzero exit code (twine-check failed)
-#     assert result.returncode != 0, \
-#         f"Expected nonzero exit code, got {result.returncode}"
-#
-#     # 2. Twine upload was attempted
-#     assert "python3 -m twine upload" in command_log, \
-#         f"Expected 'python3 -m twine upload' in log, but found:\n{command_log}"
-#
-#     # 3. No git push invocation
-#     # Note: git status and other preflight calls are expected
-#     git_push_commands = [line for line in command_log.split('\n')
-#                          if 'git push' in line]
-#     assert len(git_push_commands) == 0, \
-#         f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"
-#
-#     # 4. Script does not print successful-completion message
-#     assert "Release completed successfully" not in result.stdout, \
-#         f"Expected no success message, but stdout contains:\n{result.stdout}"
-#     assert "Release completed successfully" not in result.stderr, \
-#         f"Expected no success message, but stderr contains:\n{result.stderr}"
+
+def test_failed_twine_upload_stops_release(tmp_path):
+    """Test that a failed twine upload stops the release and does not push to git."""
+    fail_at = 'twine-upload'
+    result, command_log = run_release(tmp_path, fail_at)
+
+    # Assertions:
+
+    # 1. Script should return nonzero exit code (twine upload failed)
+    assert result.returncode != 0, \
+        f"Expected nonzero exit code, got {result.returncode}"
+
+    # 2. Twine upload was attempted
+    assert "python3 -m twine upload" in command_log, \
+        f"Expected 'python3 -m twine upload' in log, but found:\n{command_log}"
+
+    # 3. No git push invocation
+    git_push_commands = [line for line in command_log.split('\n')
+                         if 'git push' in line]
+    assert len(git_push_commands) == 0, \
+        f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"
+
+    # 4. Script does not print successful-completion message
+    assert "Release completed successfully" not in result.stdout, \
+        f"Expected no success message, but stdout contains:\n{result.stdout}"
+    assert "Release completed successfully" not in result.stderr, \
+        f"Expected no success message, but stderr contains:\n{result.stderr}"
 
 
+def test_missing_dependencies_stops_release(tmp_path):
+    """Test that missing Python dependencies stop the release before version changes."""
+    fail_at = 'missing-dependencies'
+    result, command_log = run_release(tmp_path, fail_at)
+
+    # Assertions:
+
+    # 1. Script should return nonzero exit code (dependency check failed)
+    assert result.returncode != 0, \
+        f"Expected nonzero exit code, got {result.returncode}"
+
+    # 2. Import check was attempted
+    assert "import " in command_log, \
+        f"Expected import check in log, but found:\n{command_log}"
+
+    # 3. No build invocation
+    assert "python3 -m build" not in command_log, \
+        f"Expected no build, but found:\n{command_log}"
+
+    # 4. No bumpversion invocation
+    bumpversion_commands = [line for line in command_log.split('\n')
+                            if 'bumpversion' in line]
+    assert len(bumpversion_commands) == 0, \
+        f"Expected no bumpversion, but found:\n{chr(10).join(bumpversion_commands)}"
+
+    # 5. Script does not print successful-completion message
+    assert "Release completed successfully" not in result.stdout, \
+        f"Expected no success message, but stdout contains:\n{result.stdout}"
+
+
+def test_unsupported_python_version_stops_release(tmp_path):
+    """Test that an unsupported Python version stops the release before version changes."""
+    fail_at = 'python-version'
+    result, command_log = run_release(tmp_path, fail_at)
+
+    # Assertions:
+
+    # 1. Script should return nonzero exit code (version check failed)
+    assert result.returncode != 0, \
+        f"Expected nonzero exit code, got {result.returncode}"
+
+    # 2. Version check was attempted
+    assert "sys.version_info" in command_log, \
+        f"Expected version check in log, but found:\n{command_log}"
+
+    # 3. No build invocation
+    assert "python3 -m build" not in command_log, \
+        f"Expected no build, but found:\n{command_log}"
+
+    # 4. No bumpversion invocation
+    bumpversion_commands = [line for line in command_log.split('\n')
+                            if 'bumpversion' in line]
+    assert len(bumpversion_commands) == 0, \
+        f"Expected no bumpversion, but found:\n{chr(10).join(bumpversion_commands)}"
+
+    # 5. Script does not print successful-completion message
+    assert "Release completed successfully" not in result.stdout, \
+        f"Expected no success message, but stdout contains:\n{result.stdout}"
+
+
+def test_dirty_working_tree_stops_release(tmp_path):
+    """Test that a dirty working tree stops the release before version changes."""
+    fail_at = 'dirty-tree'
+    result, command_log = run_release(tmp_path, fail_at)
+
+    # Assertions:
+
+    # 1. Script should return nonzero exit code (git status check failed)
+    assert result.returncode != 0, \
+        f"Expected nonzero exit code, got {result.returncode}"
+
+    # 2. Git status check was attempted
+    assert "git status" in command_log, \
+        f"Expected 'git status' in log, but found:\n{command_log}"
+
+    # 3. No build invocation
+    assert "python3 -m build" not in command_log, \
+        f"Expected no build, but found:\n{command_log}"
+
+    # 4. No bumpversion invocation
+    bumpversion_commands = [line for line in command_log.split('\n')
+                            if 'bumpversion' in line]
+    assert len(bumpversion_commands) == 0, \
+        f"Expected no bumpversion, but found:\n{chr(10).join(bumpversion_commands)}"
+
+    # 5. Script does not print successful-completion message
+    assert "Release completed successfully" not in result.stdout, \
+        f"Expected no success message, but stdout contains:\n{result.stdout}"
+
+
+def test_missing_gpg_key_stops_release(tmp_path):
+    """Test that a missing GPG key stops the release before version changes."""
+    fail_at = 'missing-gpg-key'
+    result, command_log = run_release(tmp_path, fail_at)
+
+    # Assertions:
+
+    # 1. Script should return nonzero exit code (GPG key check failed)
+    assert result.returncode != 0, \
+        f"Expected nonzero exit code, got {result.returncode}"
+
+    # 2. GPG key check was attempted
+    assert "gpg --list-secret-keys" in command_log, \
+        f"Expected 'gpg --list-secret-keys' in log, but found:\n{command_log}"
+
+    # 3. No build invocation
+    assert "python3 -m build" not in command_log, \
+        f"Expected no build, but found:\n{command_log}"
+
+    # 4. No bumpversion invocation
+    bumpversion_commands = [line for line in command_log.split('\n')
+                            if 'bumpversion' in line]
+    assert len(bumpversion_commands) == 0, \
+        f"Expected no bumpversion, but found:\n{chr(10).join(bumpversion_commands)}"
+
+    # 5. Script does not print successful-completion message
+    assert "Release completed successfully" not in result.stdout, \
+        f"Expected no success message, but stdout contains:\n{result.stdout}"

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -233,20 +233,20 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
 
     # 3. No GPG signing invocation (--detach-sign)
     # Note: --list-secret-keys is expected for preflight check
-    gpg_sign_commands = [line for line in command_log.split('\n') 
+    gpg_sign_commands = [line for line in command_log.split('\n')
                          if 'gpg' in line and '--detach-sign' in line]
     assert len(gpg_sign_commands) == 0, \
         f"Expected no GPG signing, but found:\n{chr(10).join(gpg_sign_commands)}"
 
     # 4. No twine check or upload invocation
-    twine_commands = [line for line in command_log.split('\n') 
+    twine_commands = [line for line in command_log.split('\n')
                       if 'python3 -m twine' in line]
     assert len(twine_commands) == 0, \
         f"Expected no twine invocations, but found:\n{chr(10).join(twine_commands)}"
 
     # 5. No git push invocation
     # Note: git status and other preflight calls are expected
-    git_push_commands = [line for line in command_log.split('\n') 
+    git_push_commands = [line for line in command_log.split('\n')
                          if 'git push' in line]
     assert len(git_push_commands) == 0, \
         f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -17,10 +17,11 @@ import shutil
 import subprocess
 from pathlib import Path
 
+
 def create_fake_python3(bin_dir: Path, log_file: Path) -> None:
     """Create a fake python3 executable that handles version probes, import checks,
     and records -m build and -m twine invocations."""
-    
+
     fake_python = bin_dir / "python3"
     fake_python.write_text(f'''#!/usr/bin/env bash
 set -e
@@ -60,9 +61,10 @@ exit 1
 ''', encoding='utf-8')
     fake_python.chmod(0o755)
 
+
 def create_fake_git(bin_dir: Path, log_file: Path, test_dir: Path) -> None:
     """Create a fake git executable that handles status, remote, and push commands."""
-    
+
     fake_git = bin_dir / "git"
     fake_git.write_text(f'''#!/usr/bin/env bash
 set -e
@@ -114,9 +116,10 @@ exit 0
 ''', encoding='utf-8')
     fake_git.chmod(0o755)
 
+
 def create_fake_gpg(bin_dir: Path, log_file: Path) -> None:
     """Create a fake gpg executable that handles key checks and signing."""
-    
+
     fake_gpg = bin_dir / "gpg"
     fake_gpg.write_text(f'''#!/usr/bin/env bash
 set -e
@@ -142,9 +145,10 @@ exit 0
 ''', encoding='utf-8')
     fake_gpg.chmod(0o755)
 
+
 def create_fake_bumpversion(bin_dir: Path, log_file: Path, test_dir: Path) -> None:
     """Create a fake bumpversion executable that simulates version bumping."""
-    
+
     fake_bumpversion = bin_dir / "bumpversion"
     fake_bumpversion.write_text(f'''#!/usr/bin/env bash
 set -e
@@ -159,8 +163,10 @@ exit 0
 ''', encoding='utf-8')
     fake_bumpversion.chmod(0o755)
 
+
 def test_failed_build_does_not_sign_upload_or_push(tmp_path):
     """Test that when python3 -m build fails, the script does not sign, upload, or push."""
+
     # Setup test directory structure
     test_dir = tmp_path / "test_release_script"
     test_dir.mkdir()
@@ -211,40 +217,48 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
         capture_output=True,
         text=True
     )
-    
+
+
     # Read the command log
     command_log = log_file.read_text()
-    
+
+
     # Assertions:
-    
+
+
     # 1. Script should return nonzero exit code (build failed)
     assert result.returncode != 0, \
         f"Expected nonzero exit code, got {result.returncode}"
-    
+
+
     # 2. Build was attempted
     assert "python3 -m build" in command_log, \
         f"Expected 'python3 -m build' in log, but found:\n{command_log}"
-    
+
+
     # 3. No GPG signing invocation (--detach-sign)
     # Note: --list-secret-keys is expected for preflight check
     gpg_sign_commands = [line for line in command_log.split('\n') 
                          if 'gpg' in line and '--detach-sign' in line]
     assert len(gpg_sign_commands) == 0, \
         f"Expected no GPG signing, but found:\n{chr(10).join(gpg_sign_commands)}"
-    
+
+
     # 4. No twine check or upload invocation
     twine_commands = [line for line in command_log.split('\n') 
                       if 'python3 -m twine' in line]
     assert len(twine_commands) == 0, \
         f"Expected no twine invocations, but found:\n{chr(10).join(twine_commands)}"
-    
+
+
     # 5. No git push invocation
     # Note: git status and other preflight calls are expected
     git_push_commands = [line for line in command_log.split('\n') 
                          if 'git push' in line]
     assert len(git_push_commands) == 0, \
         f"Expected no 'git push', but found:\n{chr(10).join(git_push_commands)}"
-    
+
+
     # 6. Script does not print successful-completion message
     assert "Release completed successfully" not in result.stdout, \
         f"Expected no success message, but stdout contains:\n{result.stdout}"
@@ -252,4 +266,3 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
         f"Expected no success message, but stderr contains:\n{result.stderr}"
     temp_directory = tmp_path / "test_release"
     temp_directory.mkdir()
-

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -29,34 +29,33 @@ set -e
 LOG_FILE="{log_file}"
 
 # Log all invocations
-echo "python3 $*" >> "$LOG_FILE"
+echo "python3 $@" >> "$LOG_FILE"
 
 # Handle version check
-if [[ "$*" == *"sys.version_info"* ]]; then
+if [[ "$1" == "-c" ]] && [[ "$2" == *"sys.version_info"* ]]; then
     echo "3.11"
     exit 0
 fi
 
 # Handle import checks
-if [[ "$*" == "-c "* ]] && [[ "$*" == *"import "* ]]; then
-    # Extract module name - handle cases like "import setuptools"
+if [[ "$1" == "-c" ]] && [[ "$2" == *"import "* ]]; then
     exit 0
 fi
 
 # Handle -m build - return failure for this test
-if [[ "$*" == "-m build"* ]]; then
+if [[ "$1" == "-m" ]] && [[ "$2" == "build" ]]; then
     echo "ERROR: Build failed" >&2
     exit 1
 fi
 
 # Handle -m twine - should not be called in this test
-if [[ "$*" == "-m twine"* ]]; then
+if [[ "$1" == "-m" ]] && [[ "$2" == "twine" ]]; then
     echo "ERROR: twine should not be called after build failure" >&2
     exit 1
 fi
 
 # Default: unknown invocation
-echo "ERROR: Unknown python3 invocation: $*" >&2
+echo "ERROR: Unknown python3 invocation: $@" >&2
 exit 1
 ''', encoding='utf-8')
     fake_python.chmod(0o755)
@@ -67,12 +66,11 @@ def create_fake_git(bin_dir: Path, log_file: Path, test_dir: Path) -> None:
 
     fake_git = bin_dir / "git"
     fake_git.write_text(f'''#!/usr/bin/env bash
-set -e
 
 LOG_FILE="{log_file}"
 
 # Log all invocations
-echo "git $*" >> "$LOG_FILE"
+echo "git $@" >> "$LOG_FILE"
 
 case "$1" in
     status)
@@ -101,18 +99,21 @@ case "$1" in
         fi
         ;;
     describe)
-        if [[ "$*" == *"--exact-match"* ]] && [[ "$*" == *"--tags"* ]]; then
+        if [[ "$2" == "--exact-match" ]] && [[ "$3" == "--tags" ]]; then
             echo "v0.9.11"
             exit 0
         fi
         ;;
     push)
-        # This should NOT be called in this test
-        exit 0
+        # Forbidden operation - fail immediately
+        echo "ERROR: git push should not be called in this test" >&2
+        exit 1
         ;;
 esac
 
-exit 0
+# Default: unknown invocation
+echo "ERROR: Unknown git invocation: $@" >&2
+exit 1
 ''', encoding='utf-8')
     fake_git.chmod(0o755)
 
@@ -122,26 +123,28 @@ def create_fake_gpg(bin_dir: Path, log_file: Path) -> None:
 
     fake_gpg = bin_dir / "gpg"
     fake_gpg.write_text(f'''#!/usr/bin/env bash
-set -e
 
 LOG_FILE="{log_file}"
 
 # Log all invocations
-echo "gpg $*" >> "$LOG_FILE"
+echo "gpg $@" >> "$LOG_FILE"
 
 # Handle --list-secret-keys (preflight check)
-if [[ "$*" == *"--list-secret-keys"* ]]; then
+if [[ "$1" == "--list-secret-keys" ]]; then
     # Just succeed - key exists
     exit 0
 fi
 
 # Handle signing with --detach-sign
-if [[ "$*" == *"--detach-sign"* ]]; then
-    # This should NOT be called in this test (build failed)
-    exit 0
+if [[ "$2" == "-u" ]] && [[ "$4" == "--detach-sign" ]]; then
+    # Forbidden operation - fail immediately
+    echo "ERROR: gpg --detach-sign should not be called in this test (build failed)" >&2
+    exit 1
 fi
 
-exit 0
+# Default: unknown invocation
+echo "ERROR: Unknown gpg invocation: $@" >&2
+exit 1
 ''', encoding='utf-8')
     fake_gpg.chmod(0o755)
 
@@ -156,7 +159,7 @@ set -e
 LOG_FILE="{log_file}"
 
 # Log all invocations
-echo "bumpversion $*" >> "$LOG_FILE"
+echo "bumpversion $@" >> "$LOG_FILE"
 
 # Simulate successful version bump
 exit 0
@@ -208,8 +211,8 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
     env["RELEASE_TEST_LOG"] = str(log_file)
 
-    # Run release.sh with arguments that trigger production path
-    # Using test mode (no --production) to avoid git push requirement during preflight
+    # Run release.sh in test mode (TestPyPI, no --production flag)
+    # This avoids git push requirement during preflight
     result = subprocess.run(
         ["bash", str(test_release_script), "--key-id", "test-key-123"],
         cwd=test_dir,
@@ -256,5 +259,3 @@ def test_failed_build_does_not_sign_upload_or_push(tmp_path):
         f"Expected no success message, but stdout contains:\n{result.stdout}"
     assert "Release completed successfully" not in result.stderr, \
         f"Expected no success message, but stderr contains:\n{result.stderr}"
-    temp_directory = tmp_path / "test_release"
-    temp_directory.mkdir()


### PR DESCRIPTION
VDNS-446 

Problem: The current release script can continue after a failed artifact build. During the v0.9.10 release, python3 setup.py sdist bdist_wheel failed because the active Python environment was missing release/build tooling, but the script continued into signing, upload, and Git push steps.

Code changes to address the problem:

-added set -euo pipefail  to top of file as requested 
-added preflight checks to ensure packages are installed, correct python version, GPG key exists locally etc
-Changed from python3 setup.py sdist bdist_wheel (deprecated) to python3 -m build (modern standard) (this was AI suggestion so not sure if it should be kept the original)
-added python3 -m twine check and python3 -m twine upload
-Added twine check before upload to catch metadata issues early
-AI adjusted error messages so also not sure if that should be reverted back it changed it so all errors go to stderr (>&2)

TESTING :
-have not tested yet 