### PR TITLE
Updating README.md to include new workflows and usage examples and remove outdated information

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Production-ready Python client for [VinylDNS](https://www.vinyldns.io/)
 
-Direct support requests and bug reports to [GitHub Issues](https://github.com/vinyldns/vinyldns-python/issues). 
+Direct support requests and bug reports to [GitHub Issues](https://github.com/vinyldns/vinyldns-python/issues).
 
 ## Requirements
 
@@ -23,8 +23,9 @@ pip install vinyldns-python
 
 To run, `pip install vinyldns-python` and then:
 
+**Option 1: Explicit credentials**
+
 ```python
->>> from vinyldns.client import VinylDNSClient
 from vinyldns.client import VinylDNSClient
 
 client = VinylDNSClient(
@@ -32,14 +33,26 @@ client = VinylDNSClient(
     "my-access-key",
     "my-secret-key"
 )
->>> local_client.list_zones()
->>>
->>> # Alternatively, configure authentication through environment variables:
->>> # - export VINYLDNS_API_URL
->>> # - export VINYLDNS_ACCESS_KEY_ID
->>> # - export VINYLDNS_SECRET_ACCESS_KEY
->>> from vinyldns.client import VinylDNSClient
->>> local_client = VinylDNSClient.from_env()
+
+# Use the client
+zones = client.list_zones()
+```
+**Option 2: Environment-based credentials**
+
+First, set the required environment variables:
+```bash
+export VINYLDNS_API_URL="https://vinyldns.example.com"
+export VINYLDNS_ACCESS_KEY_ID="my-access-key"
+export VINYLDNS_SECRET_ACCESS-KEY="my-secret-key"
+```
+
+Then in your python code:
+```python
+from vinyldns.client import VinylDNSClient
+client = VinylDNSClient.from_env()
+
+# Use the client
+zones = client.list_zones()
 ```
 
 ## Utilities
@@ -66,7 +79,7 @@ Install the package in editable mode with development dependencies:
 
 ```bash
 pip install -e .
-pip install tox pre-commit  # On Windows: .venv\Scripts\activate
+pip install tox pre-commit
 ```
 
 Install pre-commit hooks:
@@ -148,6 +161,8 @@ print(f"Deleted record set with change ID: {delete_change.id}")
 ```
 
 **Work with Groups**
+
+The following examples modify DNS data:
 ```python
 from vinyldns.membership import Group, User
 
@@ -181,32 +196,32 @@ for member in members.members:
 
 The following examples modify DNS data:
 ```python
-from vinyldns.batch_change import BatchChangeInput, AddChangeInput, DeleteChangeInput
+from vinyldns.batch_change import BatchChangeRequest, AddRecord, DeleteRecordSet
 
 # Create a batch change with multiple updates
-batch_input = BatchChangeInput(
+batch_request = BatchChangeRequest(
     comments="Update DNS records for new deployment",
     changes=[
-        AddChangeInput(
+        AddRecord(
             input_name="app.example.com.",
             type="A",
             ttl=300,
             record={"address": "192.0.2.100"}
         ),
-        AddChangeInput(
+        AddRecord(
             input_name="api.example.com.",
             type="CNAME",
             ttl=300,
             record={"cname": "app.example.com."}
         ),
-        DeleteChangeInput(
+        DeleteRecordSet(
             input_name="old-app.example.com.",
             type="A"
         )
     ]
 )
 
-batch_change = client.create_batch_change(batch_input)
+batch_change = client.create_batch_change(batch_request)
 print(f"Batch change created: {batch_change.id}")
 print(f"Status: {batch_change.status}")
 
@@ -249,7 +264,7 @@ This workflow requires Docker to be installed and running.
 **Running a full build**
 
 When you are finished writing your code you will want to run everything including linters.  The
-simplest way to do this is to run `tox -e check,py36`, which will run static checks and run unit tests.
+simplest way to do this is to run `tox -e check,py3`, which will run static checks and run unit tests.
 
 If you see any failures / warnings, correct them until `tox` runs successfully.
 
@@ -258,9 +273,34 @@ read the [tox docs](https://tox.readthedocs.io/en/latest/index.html).
 
 
 ## Local Development
-See the [quickstart](https://github.com/vinyldns/vinyldns/blob/master/README.md#quickstart) in the
-VinylDNS api for details on how to start up a local instance of the api in docker. With that
-running, you can make requests with the following client details:
+
+The repository includes a self-contained Docker environment for local testing and development. This is the same environment used by the functional tests.
+
+**Starting the VinylDNS environment:**
+
+```bash
+bash ./docker/docker-up-vinyldns.sh
+```
+
+This starts VinylDNS API on `http://localhost:9000` along with MySQL and BIND9 dependencies.
+
+**Connecting to the local environment:**
 ```python
 local_client = VinylDNSClient("http://localhost:9000", "okAccessKey", "okSecretKey")
 ```
+
+**Stopping the environment:**
+
+```bash
+./docker/remove-vinyl-containers.sh
+```
+
+**Running tests against the local environment:**
+
+The functional tests automatically manage the Docker environment:
+
+```bash
+tox -e func_test
+```
+
+This will start the VinylDNS Docker environment, run all functional tests against it, and tear it down when complete.

--- a/README.md
+++ b/README.md
@@ -1,60 +1,250 @@
-[![PyPI version](https://badge.fury.io/py/vinyldns-python.svg)](https://badge.fury.io/py/vinyldns-python) [![Travis build](https://api.travis-ci.org/vinyldns/vinyldns-python.svg?branch=master)](https://travis-ci.org/vinyldns/vinyldns-python)
+[![PyPI version](https://badge.fury.io/py/vinyldns-python.svg)](https://badge.fury.io/py/vinyldns-python)
+[![Verify & Code-Coverage](https://github.com/vinyldns/vinyldns-python/actions/workflows/verify.yml/badge.svg)](https://github.com/vinyldns/vinyldns-python/actions/workflows/verify.yml)
+[![codecov](https://codecov.io/gh/vinyldns/vinyldns-python/branch/master/graph/badge.svg)](https://codecov.io/gh/vinyldns/vinyldns-python)
 ![GitHub](https://img.shields.io/github/license/vinyldns/vinyldns-python)
 
 # vinyldns-python
 
-Python client library for [VinylDNS](https://www.vinyldns.io/)
+Production-ready Python client for [VinylDNS](https://www.vinyldns.io/)
 
-This project is a work in progress! If you would like to help us get this where it needs to be,
-please reach out to us in [gitter](https://gitter.im/vinyldns/Lobby).
+Direct support requests and bug reports to [GitHub Issues](https://github.com/vinyldns/vinyldns-python/issues). 
+
+## Requirements
+
+Python 3.11 or newer is required.
+
+## Installation
+
+Install from PyPI:
+
+```bash
+pip install vinyldns-python
+```
 
 To run, `pip install vinyldns-python` and then:
 
 ```python
 >>> from vinyldns.client import VinylDNSClient
->>> local_client = VinylDNSClient("ApiEndpoint", "UserAccessKey", "UserSecretKey")
+from vinyldns.client import VinylDNSClient
+
+client = VinylDNSClient(
+    "https://vinyldns.example.com",
+    "my-access-key",
+    "my-secret-key"
+)
 >>> local_client.list_zones()
 >>>
->>> # If all of the following environments are set
->>> # - VINYLDNS_API_URL
->>> # - VINYLDNS_ACCESS_KEY_ID
->>> # - VINYLDNS_SECRET_ACCESS_KEY
+>>> # Alternatively, configure authentication through environment variables:
+>>> # - export VINYLDNS_API_URL
+>>> # - export VINYLDNS_ACCESS_KEY_ID
+>>> # - export VINYLDNS_SECRET_ACCESS_KEY
 >>> from vinyldns.client import VinylDNSClient
 >>> local_client = VinylDNSClient.from_env()
->>> local_client.list_zones()
 ```
 
+## Utilities
+
+Several command-line utilities are available under scripts/ for common VinylDNS operations.
 ## Contributing
 
 **Requirements**
 
-* `python3`
+* `python3.11 or newer`
 * `pip`
 * `virtualenv`
+* `tox`
 * `pre-commit`
 
-To get started, you will want to setup your virtual environment.
+## Setup
+Create and activate a virtual environment.
 
-1. Ensure that you have `virtualenv` installed `> pip install virtualenv`
-1. Run `./bootstrap.sh` to setup your environment (unless you really want all these dependencies to be installed locally, which we do not recommend).
-1. Activate your virtual environment `> source .virtualenv/bin/activate`
-2. Install pre-commit so you can enable any pre-commit hooks > `pip install pre-commit`
-3. Enable the pre-commit hooks `> pre-commit install`. If installed correctly, you should see the following output: pre-commit installed at .git/hooks/pre-commit
+```bash
+python3 -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+```
+Install the package in editable mode with development dependencies:
 
-**Unit Tests**
+```bash
+pip install -e .
+pip install tox pre-commit  # On Windows: .venv\Scripts\activate
+```
+
+Install pre-commit hooks:
+
+```bash
+pre-commit install
+```
+
+## Usage Examples
+
+You can reference the [VinylDNS API documentation](https://www.vinyldns.io/api/index.html) for more details on each endpoint.
+
+**List Zones**
+```python
+from vinyldns.client import VinylDNSClient
+
+client = VinylDNSClient.from_env()
+
+# List all zones
+zones = client.list_zones()
+for zone in zones.zones:
+    print(f"{zone.name} - {zone.id}")
+
+# Filter zones by name
+filtered_zones = client.list_zones(name_filter="example")
+```
+
+**Retrieve and list record sets**
+```python
+# Get a specific record set
+record_set = client.get_record_set(zone_id="zone-123", rs_id="recordset-456")
+print(f"{record_set.name} {record_set.type} {record_set.ttl}")
+
+# List all record sets in a zone
+record_sets = client.list_record_sets(zone_id="zone-123")
+for rs in record_sets.record_sets:
+    print(f"{rs.name} {rs.type}")
+
+# Filter record sets by name
+filtered_rs = client.list_record_sets(
+    zone_id="zone-123",
+    record_name_filter="www"
+)
+
+# Search record sets globally across all zones
+search_results = client.search_record_sets(
+    record_name_filter="api",
+    record_type_filter=["A", "CNAME"]
+)
+```
+
+**Create and update a record set**
+
+The following examples modify DNS data:
+```python
+from vinyldns.record import RecordSet
+
+# Create a new A record
+new_record = RecordSet(
+    zone_id="zone-123",
+    name="app",
+    type="A",
+    ttl=300,
+    records=[{"address": "192.0.2.10"}]
+)
+change = client.create_record_set(new_record)
+print(f"Created record set with change ID: {change.id}")
+
+# Update an existing record set
+record_set = client.get_record_set(zone_id="zone-123", rs_id="recordset-456")
+record_set.ttl = 600
+record_set.records = [{"address": "192.0.2.20"}]
+update_change = client.update_record_set(record_set)
+print(f"Updated record set with change ID: {update_change.id}")
+
+# Delete a record set
+delete_change = client.delete_record_set(zone_id="zone-123", rs_id="recordset-456")
+print(f"Deleted record set with change ID: {delete_change.id}")
+```
+
+**Work with Groups**
+```python
+from vinyldns.membership import Group, User
+
+# Create a group
+new_group = Group(
+    name="engineering-team",
+    email="engineering@example.com",
+    description="Engineering team DNS access",
+    members=[User(id="user-123")],
+    admins=[User(id="user-123")]
+)
+created_group = client.create_group(new_group)
+print(f"Created group: {created_group.id}")
+
+# Get a group
+group = client.get_group("group-456")
+print(f"Group name: {group.name}")
+
+# List my groups
+my_groups = client.list_my_groups()
+for group in my_groups.groups:
+    print(f"{group.name} - {group.id}")
+
+# List group members
+members = client.list_members_group(group_id="group-456")
+for member in members.members:
+    print(f"Member: {member.user_name}")
+```
+
+**Create a Batch Change**
+
+The following examples modify DNS data:
+```python
+from vinyldns.batch_change import BatchChangeInput, AddChangeInput, DeleteChangeInput
+
+# Create a batch change with multiple updates
+batch_input = BatchChangeInput(
+    comments="Update DNS records for new deployment",
+    changes=[
+        AddChangeInput(
+            input_name="app.example.com.",
+            type="A",
+            ttl=300,
+            record={"address": "192.0.2.100"}
+        ),
+        AddChangeInput(
+            input_name="api.example.com.",
+            type="CNAME",
+            ttl=300,
+            record={"cname": "app.example.com."}
+        ),
+        DeleteChangeInput(
+            input_name="old-app.example.com.",
+            type="A"
+        )
+    ]
+)
+
+batch_change = client.create_batch_change(batch_input)
+print(f"Batch change created: {batch_change.id}")
+print(f"Status: {batch_change.status}")
+
+# Get batch change status
+batch_status = client.get_batch_change(batch_change.id)
+print(f"Current status: {batch_status.status}")
+
+# List batch change summaries
+batch_summaries = client.list_batch_change_summaries()
+for summary in batch_summaries.batch_changes:
+    print(f"{summary.user_name} - {summary.created_timestamp} - {summary.status}")
+```
+
+
+## Running Unit Tests
 
 Unit tests are developed using [pytest](https://docs.pytest.org/en/latest/).  We use
 [Responses](https://github.com/getsentry/responses), which allows for simple mocking of HTTP endpoints.
 
-To run unit tests, you can simply run `python3 setup.py test`.  To target a specific test, you can
-run `python3 setup.py test -a "-k my_test"`
+Run static checks and unit tests:
+
+```bash
+tox -e check,py3
+```
+
+Verify Apache license headers are present:
+
+```bash
+pre-commit run apache-license-header-check --all-files
+```
 
 **Functional Tests**
 
-Functional tests are also developed with pytest. These tests run against a local instance of VinylDNS. Note that for now
-they are not tied into our travis build, so they must be run locally for validation.
+The functional tests start a self-contained Docker-based VinylDNS environment, run tests against it, and tear it down:
 
 From your virtualenv, run `tox -e func_test`
+
+This workflow requires Docker to be installed and running.
 
 **Running a full build**
 
@@ -66,7 +256,6 @@ If you see any failures / warnings, correct them until `tox` runs successfully.
 If you do not have `tox` in your environment, `pip install tox` to add it.  For more information you can
 read the [tox docs](https://tox.readthedocs.io/en/latest/index.html).
 
-You will also want to run the apache pre-commit hook check to make sure no files are missing the license before pushing code. To do this run `pre-commit run apache-license-header-check --all-files`
 
 ## Local Development
 See the [quickstart](https://github.com/vinyldns/vinyldns/blob/master/README.md#quickstart) in the

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ First, set the required environment variables:
 ```bash
 export VINYLDNS_API_URL="https://vinyldns.example.com"
 export VINYLDNS_ACCESS_KEY_ID="my-access-key"
-export VINYLDNS_SECRET_ACCESS-KEY="my-secret-key"
+export VINYLDNS_SECRET_ACCESS_KEY="my-secret-key"
 ```
 
 Then in your python code:


### PR DESCRIPTION
[VDNS-448](https://tpx.sys.comcast.net/projects/VDNS/issues/VDNS-448)

Problem: The vinyldns-python README contains outdated project, support, CI, and contributor information. Update it so users can install and use the client, while contributors can set up and validate changes using the current repository workflow.

Changes:
Updated README.md to:

Describe the project as a production-ready Python client for VinylDNS.
Direct support requests and bug reports to [GitHub Issues](https://github.com/vinyldns/vinyldns-python/issues).
Replace the Travis badge with the GitHub Actions verification badge.
Add the Codecov badge while retaining the PyPI and license badges.
State that Python 3.11 or newer is required.
Document installation from PyPI with pip install vinyldns-python.
Document authentication through explicit API URL, access key, and secret key arguments.
Document authentication through VINYLDNS_API_URL, VINYLDNS_ACCESS_KEY_ID, and VINYLDNS_SECRET_ACCESS_KEY.
Add concise examples for listing zones; retrieving and listing record sets; creating and updating a record set; working with groups; and creating a batch change.
Clearly identify examples that modify DNS data and use obvious placeholder values.
Link to the VinylDNS API documentation for complete API behavior.
Briefly mention the utilities available under scripts/.
Replace the legacy bootstrap.sh and setup.py test instructions with a standard virtual environment, editable package installation, tox, and pre-commit workflow.
Document contributor validation with tox -e check,py3 and pre-commit run apache-license-header-check --all-files.
Document tox -e func_test as the self-contained functional-test workflow that starts and removes its Docker-based VinylDNS environment.
Remove references to Gitter, Travis CI, Python 3.6, and the external quickstart requirement.

